### PR TITLE
docs: refresh per-package READMEs to match current code

### DIFF
--- a/packages/fastopendata/README.md
+++ b/packages/fastopendata/README.md
@@ -13,17 +13,28 @@ from the monorepo root. See the [root README](../../README.md) for setup instruc
 
 ## Quick Start
 
+`GraphPipeline` collects entities and relationships from multiple sources
+and produces a `pycypher.Context` (or fully-built `Star`) ready for queries:
+
 ```python
-from fastopendata import GraphPipeline, config
+import pandas as pd
+from fastopendata import GraphPipeline
 
-# Configure data paths
-config.raw_data_dir = "raw_data/"
-config.output_dir = "output/"
+people = pd.DataFrame({"id": [1, 2], "name": ["Alice", "Bob"]})
+knows = pd.DataFrame({"src": [1], "dst": [2]})
 
-# Build a processing pipeline
 pipeline = GraphPipeline()
-pipeline.run()
+pipeline.add_entity_dataframe("Person", people, id_col="id")
+pipeline.add_relationship_dataframe(
+    "KNOWS", knows, source_col="src", target_col="dst"
+)
+star = pipeline.build_star()  # or .build_context() for a raw Context
+result = star.execute_query("MATCH (p:Person) RETURN p.name")
 ```
+
+Path configuration (data dir, scripts dir, etc.) is read from the
+`Config` singleton and the `DATA_DIR` environment variable; see
+`fastopendata.config` for the full surface.
 
 ## Features
 
@@ -36,15 +47,21 @@ pipeline.run()
 
 ## Processing Scripts
 
-The `processing/` directory contains standalone scripts for each data source:
+`src/fastopendata/processing/` contains standalone scripts for each data
+source. See `src/fastopendata/processing/PROCESSING_SCRIPTS.md` for the
+authoritative list; the most-used entries:
 
 | Script | Purpose |
 |--------|---------|
 | `download_block_shape_files.sh` | Fetch Census block shapefiles |
 | `concatenate_shape_files.py` | Merge shapefiles into unified datasets |
+| `concatenate_puma_shape_files.py` | Merge PUMA shapefiles |
 | `extract_osm_nodes.py` | Extract nodes from OSM PBF files |
 | `filter_us_nodes.py` | Filter to US geographic bounds |
 | `compress_wikidata.py` | Compress Wikidata JSON dumps |
+| `wikidata_to_csv.py` | Convert Wikidata dumps to CSV format |
+| `extract_pums_5year.sh` | Pull Census PUMS 5-year microdata |
+| `extract_state_contracts.py` | Extract state-level contract records |
 
 ## Dependencies
 

--- a/packages/pycypher/README.md
+++ b/packages/pycypher/README.md
@@ -8,7 +8,7 @@ PyCypher parses [Cypher](https://neo4j.com/docs/cypher-manual/) graph queries an
 
 ## Installation
 
-PyCypher requires **Python 3.14+** and uses `uv` for dependency management.
+PyCypher requires **Python 3.12+** and uses `uv` for dependency management.
 It is not yet published on PyPI — install from source:
 
 ```bash
@@ -130,7 +130,8 @@ nmetl metrics --diagnostic
 
 ## Examples
 
-See the [`examples/`](examples/) directory for runnable scripts:
+Runnable example scripts live at the **monorepo root** in
+[`../../examples/`](../../examples/):
 
 - `hello_world.py` — 5-level progression from basic MATCH to aggregation
 - `quickstart.py` — 30-line intro with error handling


### PR DESCRIPTION
## Summary

Surgical updates to per-package READMEs flagged stale by the doc audit. Every retained or new claim was verified against the current code on `main`.

### `packages/pycypher/README.md`
- Corrected Python requirement (`3.14+` → `3.12+`; matches `pyproject.toml` `requires-python = ">=3.12"`).
- Pointed the **Examples** section at `../../examples/` (the monorepo root, where the listed scripts actually live). The in-package `examples/` directory does not exist.

### `packages/fastopendata/README.md`
- Replaced the broken **Quick Start** snippet (`config.raw_data_dir = ...` attribute assignment, nonexistent `pipeline.run()`) with the actual `GraphPipeline` API: `add_entity_dataframe` / `add_relationship_dataframe` / `build_star` / `build_context`.
- Added a one-line note about `Config` + `DATA_DIR` env-var configuration (verified at `src/fastopendata/config.py:582` and `:357`).
- Expanded the **Processing Scripts** table with four scripts that already shipped under `src/fastopendata/processing/` but were undocumented (`concatenate_puma_shape_files.py`, `wikidata_to_csv.py`, `extract_pums_5year.sh`, `extract_state_contracts.py`).

### `packages/shared/`
- Removed the empty `README.txt` that sat next to the real `README.md`.

### Audited and left alone
- `packages/pycypher-tui/README.md` — claims (`pycypher-tui` CLI, screens, modal system, doc links) all match current code.
- `packages/shared/README.md` — every existing module entry is accurate. Some of the newer modules (`alerting`, `audit_chain`, `dashboard`, `regression_detector`, `telemetry`, `continuous_monitor`, `file_intent`) are documented in `shared/__init__.py` but not in this README; that is a completeness gap rather than a stale claim, and adding them would expand scope past the surgical-edit ask.
- `packages/nmetl/` — does not exist. `nmetl` is a `console_scripts` entry point declared in `packages/pycypher/pyproject.toml` (`pycypher.nmetl_cli:main`); no per-package README is needed.

## Test plan

- [x] Verified each retained API claim by `grep`/`Read` against the current source (e.g. `GraphPipeline.add_entity_dataframe` at `pipeline.py:229`, `build_star` at `:549`, `Config()` singleton at `config.py:582`).
- [x] Verified `examples/*.py` referenced by the pycypher README all exist at the monorepo root.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)