### PR TITLE
fix: address remaining type bugs surfaced by ty

### DIFF
--- a/packages/pycypher/src/pycypher/aggregation_evaluator.py
+++ b/packages/pycypher/src/pycypher/aggregation_evaluator.py
@@ -258,10 +258,13 @@ class AggregationExpressionEvaluator:
         # scalar and apply the operator.  Null-safe guards for division and
         # modulo are kept explicit; standard ops reuse _ARITH_OPS.
         if isinstance(agg_expression, Arithmetic):
-            left_val = expression_evaluator._eval_as_scalar(
+            # _eval_as_scalar is a BindingExpressionEvaluator-specific helper
+            # not exposed on the protocol; the runtime caller is always the
+            # concrete evaluator.
+            left_val = expression_evaluator._eval_as_scalar(  # ty: ignore[unresolved-attribute]
                 agg_expression.left,
             )
-            right_val = expression_evaluator._eval_as_scalar(
+            right_val = expression_evaluator._eval_as_scalar(  # ty: ignore[unresolved-attribute]
                 agg_expression.right,
             )
             op = agg_expression.operator

--- a/packages/pycypher/src/pycypher/arithmetic_evaluator.py
+++ b/packages/pycypher/src/pycypher/arithmetic_evaluator.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 import operator as _op
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, TypeGuard, cast
 
 import numpy as np
 
@@ -207,17 +207,17 @@ def _first_non_null_val(series: FrameSeries) -> Any:
 _is_null_val = is_null_value  # Canonical null-check from shared.helpers
 
 
-def _is_date_str(v: object) -> bool:
+def _is_date_str(v: object) -> TypeGuard[str]:
     """Return True when *v* is a ``'YYYY-MM-DD'`` ISO date string."""
     return isinstance(v, str) and len(v) == 10 and v[4] == "-" and v[7] == "-"
 
 
-def _is_datetime_str(v: object) -> bool:
+def _is_datetime_str(v: object) -> TypeGuard[str]:
     """Return True when *v* is an ISO datetime string (contains ``'T'``)."""
     return isinstance(v, str) and "T" in v and len(v) >= 16 and v[4] == "-"
 
 
-def _is_duration_dict(v: object) -> bool:
+def _is_duration_dict(v: object) -> TypeGuard[dict[str, int]]:
     """Return True when *v* is a duration component dict (has ``'days'`` key)."""
     return isinstance(v, dict) and "days" in v
 
@@ -334,7 +334,7 @@ def _temporal_arith_pair(op: str, left: object, right: object) -> object:
 
     # date + duration  /  date - duration
     if _is_date_str(left) and _is_duration_dict(right):
-        d = _date_cls.fromisoformat(cast(str, left))
+        d = _date_cls.fromisoformat(left)
         return _apply_duration_to_date(
             d,
             right,
@@ -343,19 +343,17 @@ def _temporal_arith_pair(op: str, left: object, right: object) -> object:
 
     # duration + date  (commutative addition only)
     if _is_duration_dict(left) and _is_date_str(right) and op == "+":
-        d = _date_cls.fromisoformat(cast(str, right))
+        d = _date_cls.fromisoformat(right)
         return _apply_duration_to_date(d, left, sign=1).isoformat()
 
     # date - date  → duration
     if _is_date_str(left) and _is_date_str(right) and op == "-":
-        delta = _date_cls.fromisoformat(
-            cast(str, left),
-        ) - _date_cls.fromisoformat(cast(str, right))
+        delta = _date_cls.fromisoformat(left) - _date_cls.fromisoformat(right)
         return _delta_to_duration(delta)
 
     # datetime + duration  /  datetime - duration
     if _is_datetime_str(left) and _is_duration_dict(right):
-        dt = _datetime_cls.fromisoformat(cast(str, left))
+        dt = _datetime_cls.fromisoformat(left)
         result = _apply_duration_to_datetime(
             dt,
             right,
@@ -366,14 +364,14 @@ def _temporal_arith_pair(op: str, left: object, right: object) -> object:
 
     # duration + datetime  (commutative addition only)
     if _is_duration_dict(left) and _is_datetime_str(right) and op == "+":
-        dt = _datetime_cls.fromisoformat(cast(str, right))
+        dt = _datetime_cls.fromisoformat(right)
         return _apply_duration_to_datetime(dt, left, sign=1).isoformat()
 
     # datetime - datetime  → duration
     if _is_datetime_str(left) and _is_datetime_str(right) and op == "-":
         delta = _datetime_cls.fromisoformat(
-            cast(str, left),
-        ) - _datetime_cls.fromisoformat(cast(str, right))
+            left,
+        ) - _datetime_cls.fromisoformat(right)
         return _delta_to_duration(delta)
 
     # duration + duration  /  duration - duration

--- a/packages/pycypher/src/pycypher/ast_models/validation.py
+++ b/packages/pycypher/src/pycypher/ast_models/validation.py
@@ -129,7 +129,7 @@ def extract_referenced_variables(node: ASTNode) -> set[str]:
     """
     refs: set[str] = set()
     for var in node.find_all(Variable):
-        refs.add(var.name)
+        refs.add(var.name)  # ty: ignore[unresolved-attribute]  # find_all(Variable) returns Variable instances; ASTNode return type is too loose
     return refs
 
 

--- a/packages/pycypher/src/pycypher/audit.py
+++ b/packages/pycypher/src/pycypher/audit.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 __all__ = [
@@ -104,7 +104,7 @@ def _emit(record: dict[str, Any]) -> None:
 
 def audit_query_success(
     *,
-    query_id: str,
+    query_id: str | None,
     query: str,
     elapsed_s: float,
     rows: int,
@@ -141,7 +141,7 @@ def audit_query_success(
 
 def audit_mutation(
     *,
-    query_id: str,
+    query_id: str | None,
     operation: str,
     entity_type: str,
     affected_count: int,
@@ -185,7 +185,7 @@ def audit_mutation(
 
 def audit_query_error(
     *,
-    query_id: str,
+    query_id: str | None,
     query: str,
     elapsed_s: float,
     error_type: str,

--- a/packages/pycypher/src/pycypher/backend_engine.py
+++ b/packages/pycypher/src/pycypher/backend_engine.py
@@ -68,7 +68,7 @@ from __future__ import annotations
 
 import enum
 import time
-from typing import Protocol, cast, runtime_checkable
+from typing import Any, Protocol, cast, runtime_checkable
 
 import pandas as pd
 from shared.logger import LOGGER
@@ -658,7 +658,7 @@ class InstrumentedBackend:
         """Return the inner backend's name."""
         return self._inner.name
 
-    def _record(self, op: str, elapsed_ms: float, span: object = None) -> None:
+    def _record(self, op: str, elapsed_ms: float, span: Any = None) -> None:
         """Record timing for an operation and annotate the OTel span."""
         self.operation_timings.setdefault(op, []).append(elapsed_ms)
         self.operation_counts[op] = self.operation_counts.get(op, 0) + 1
@@ -916,7 +916,7 @@ def select_backend_for_query(
     )
     if cardinality_estimates:
         max_cardinality = max(cardinality_estimates.values(), default=0)
-        estimated_rows = max(estimated_rows, max_cardinality)
+        estimated_rows = max(estimated_rows, int(max_cardinality))
 
     # Heuristic: if estimated rows exceed threshold and we're on pandas,
     # suggest switching to a more scalable backend

--- a/packages/pycypher/src/pycypher/backends/pandas_backend.py
+++ b/packages/pycypher/src/pycypher/backends/pandas_backend.py
@@ -85,9 +85,9 @@ class PandasBackend:
             # pandas merge uses a hash-based join internally, so pre-sorting
             # both sides is redundant O(n log n) work.  Just pass through to
             # the default merge path which is already O(n).
-            return left.merge(right, on=on, how=how)  # type: ignore[arg-type]  # pandas Literal stub
+            return left.merge(right, on=on, how=how)  # ty: ignore[invalid-argument-type]  # how is a runtime str narrowed by callers
 
-        return left.merge(right, on=on, how=how)  # type: ignore[arg-type]  # pandas Literal stub
+        return left.merge(right, on=on, how=how)  # ty: ignore[invalid-argument-type]  # pandas Literal stub: how is a runtime str narrowed by callers
 
     def rename(
         self,

--- a/packages/pycypher/src/pycypher/binding_evaluator.py
+++ b/packages/pycypher/src/pycypher/binding_evaluator.py
@@ -602,11 +602,11 @@ class BindingExpressionEvaluator:
                     if row is None or i is None:
                         return None
                     if isinstance(row, dict):
-                        # Map key access: map['key']
-                        return row.get(i)  # type: ignore[arg-type]  # runtime key is Any
-                    # List integer index access: list[0]
+                        # Map key access: map['key']; runtime row dict accepts Any key
+                        return row.get(i)  # ty: ignore[invalid-argument-type]
+                    # List integer index access: list[0]; row may be list/tuple/ndarray
                     try:
-                        return row[int(i)]  # type: ignore[call-overload,index]  # runtime i is numeric
+                        return row[int(i)]  # ty: ignore[not-subscriptable, invalid-argument-type]
                     except (IndexError, TypeError):
                         if _DEBUG_ENABLED:
                             LOGGER.debug(
@@ -1292,9 +1292,11 @@ class BindingExpressionEvaluator:
             ValueError: For unsupported aggregation functions or missing arguments.
 
         """
-        # Architecture Loop 280 - Phase 3: Delegate to specialized aggregation evaluator
+        # Architecture Loop 280 - Phase 3: Delegate to specialized aggregation evaluator.
+        # The façade widens the parameter to Expression; callers are
+        # responsible for passing aggregation-shaped nodes.
         return self.aggregation_evaluator.evaluate_aggregation(
-            agg_expression,
+            agg_expression,  # ty: ignore[invalid-argument-type]
             self,
         )
 
@@ -1332,9 +1334,10 @@ class BindingExpressionEvaluator:
             evaluation in that case.
 
         """
-        # Architecture Loop 280 - Phase 3: Delegate to specialized aggregation evaluator
+        # Architecture Loop 280 - Phase 3: Delegate to specialized aggregation evaluator.
+        # See evaluate_aggregation re: façade-vs-implementation parameter widening.
         return self.aggregation_evaluator.evaluate_aggregation_grouped(
-            agg_expression,
+            agg_expression,  # ty: ignore[invalid-argument-type]
             group_df,
             group_key_aliases,
             self,

--- a/packages/pycypher/src/pycypher/binding_frame.py
+++ b/packages/pycypher/src/pycypher/binding_frame.py
@@ -59,7 +59,7 @@ from pycypher.cypher_types import FrameDataFrame, FrameSeries
 _DEBUG_ENABLED: bool = LOGGER.isEnabledFor(logging.DEBUG)
 
 if TYPE_CHECKING:
-    pass
+    from pycypher.query_planner import JoinPlan
 
 # ---------------------------------------------------------------------------
 # Column-name constants used across the BindingFrame execution path
@@ -176,14 +176,14 @@ def _normalize_mapped_result(result: pd.Series) -> pd.Series:
 
 # Re-export from dataframe_utils for backward compatibility.
 # New code should import directly from pycypher.dataframe_utils.
-from pycypher.dataframe_utils import source_to_pandas as _source_to_pandas
+from pycypher.dataframe_utils import source_to_pandas as _source_to_pandas  # noqa: E402  # backward-compat re-export
 
 # Backward-compatible re-exports from scan_operators (extracted for SRP).
 # New code should import directly from pycypher.scan_operators.
-from pycypher.scan_operators import (
+from pycypher.scan_operators import (  # noqa: E402  # backward-compat re-export
     _coerce_pushdown_ids as _coerce_pushdown_ids,
 )
-from pycypher.scan_operators import (
+from pycypher.scan_operators import (  # noqa: E402  # backward-compat re-export
     _coerce_pushdown_series as _coerce_pushdown_series,
 )
 
@@ -530,7 +530,13 @@ class BindingFrame:
                     result = _normalize_mapped_result(result)
                     result.index = self.bindings.index
                     _used_vectorized = True
-            except (KeyError, ValueError, TypeError, IndexError, AttributeError):
+            except (
+                KeyError,
+                ValueError,
+                TypeError,
+                IndexError,
+                AttributeError,
+            ):
                 LOGGER.debug(
                     "Vectorized fetch failed for %s.%s, falling back",
                     entity_type,
@@ -563,7 +569,10 @@ class BindingFrame:
                         entity_subset[ID_COLUMN].dtype, errors="ignore"
                     )
                 joined = backend.join(
-                    id_frame, entity_subset, on=ID_COLUMN, how="left",
+                    id_frame,
+                    entity_subset,
+                    on=ID_COLUMN,
+                    how="left",
                 )
                 result = _normalize_mapped_result(joined[prop_name])
                 result.index = self.bindings.index
@@ -670,7 +679,13 @@ class BindingFrame:
                         self._property_cache[(var_name, prop)] = series
                     results.update(results_from_cache)
                     return results
-            except (KeyError, ValueError, TypeError, IndexError, AttributeError):
+            except (
+                KeyError,
+                ValueError,
+                TypeError,
+                IndexError,
+                AttributeError,
+            ):
                 LOGGER.debug(
                     "Vectorized batch fetch failed for %s, falling back",
                     entity_type,
@@ -724,7 +739,10 @@ class BindingFrame:
                         entity_subset[ID_COLUMN].dtype, errors="ignore"
                     )
                 joined = backend.join(
-                    id_frame, entity_subset, on=ID_COLUMN, how="left",
+                    id_frame,
+                    entity_subset,
+                    on=ID_COLUMN,
+                    how="left",
                 )
                 for prop in available:
                     series = joined[prop]
@@ -1045,7 +1063,7 @@ class BindingFrame:
         left_col: str,
         right_col: str,
         *,
-        join_plan: object | None = None,
+        join_plan: JoinPlan | None = None,
     ) -> BindingFrame:
         """Inner-join two BindingFrames on a pair of columns.
 
@@ -1564,9 +1582,9 @@ class BindingFrame:
             # (e.g. from REMOVE operations) which .map().notna() would miss.
             matched_mask: pd.Series = source_df[ID_COLUMN].isin(update_map)
             if matched_mask.any():
-                mapped_vals = source_df.loc[
-                    matched_mask, ID_COLUMN
-                ].map(update_map)
+                mapped_vals = source_df.loc[matched_mask, ID_COLUMN].map(
+                    update_map
+                )
                 try:
                     source_df.loc[matched_mask, prop_name] = mapped_vals
                 except (TypeError, ValueError):
@@ -1688,20 +1706,21 @@ class BindingFrame:
         for prop_name, values in properties.items():
             updates_data[prop_name] = values.values
         updates_df = pd.DataFrame(updates_data).drop_duplicates(
-            subset=[ID_COLUMN], keep="last",
+            subset=[ID_COLUMN],
+            keep="last",
         )
 
         # Single merge: left join source IDs against the updates.
         # This produces _prop_new columns for each property that has a match.
-        suffixed_cols = {
-            prop: f"_batch_{prop}" for prop in properties
-        }
+        suffixed_cols = {prop: f"_batch_{prop}" for prop in properties}
         updates_renamed = updates_df.rename(
             columns={p: s for p, s in suffixed_cols.items()},
         )
 
         merged = source_df[[ID_COLUMN]].merge(
-            updates_renamed, on=ID_COLUMN, how="left",
+            updates_renamed,
+            on=ID_COLUMN,
+            how="left",
         )
 
         # Apply each property from the merged result.
@@ -1727,7 +1746,9 @@ class BindingFrame:
                         source_df[prop_name].values,
                     )
                     source_df[prop_name] = pd.Series(
-                        combined, index=source_df.index, dtype=object,
+                        combined,
+                        index=source_df.index,
+                        dtype=object,
                     )
 
             # Register new property in attribute maps.
@@ -1757,6 +1778,6 @@ class BindingFrame:
 # Scan and filter operators — re-exported for backward compatibility.
 # New code should import directly from pycypher.scan_operators.
 # ---------------------------------------------------------------------------
-from pycypher.scan_operators import BindingFilter as BindingFilter
-from pycypher.scan_operators import EntityScan as EntityScan
-from pycypher.scan_operators import RelationshipScan as RelationshipScan
+from pycypher.scan_operators import BindingFilter as BindingFilter  # noqa: E402  # backward-compat re-export
+from pycypher.scan_operators import EntityScan as EntityScan  # noqa: E402  # backward-compat re-export
+from pycypher.scan_operators import RelationshipScan as RelationshipScan  # noqa: E402  # backward-compat re-export

--- a/packages/pycypher/src/pycypher/boolean_evaluator.py
+++ b/packages/pycypher/src/pycypher/boolean_evaluator.py
@@ -51,7 +51,7 @@ def kleene_and(left: FrameSeries, right: FrameSeries) -> FrameSeries:
         np.where(
             l_false | r_false,
             False,
-            np.where(l_null | r_null, None, True),  # type: ignore[call-overload]  # numpy stub limitation
+            np.where(l_null | r_null, None, True),  # ty: ignore[no-matching-overload]  # numpy stubs reject None as broadcast scalar
         ),
         dtype=object,
         index=left.index,
@@ -72,7 +72,7 @@ def kleene_or(left: FrameSeries, right: FrameSeries) -> FrameSeries:
         np.where(
             l_true | r_true,
             True,
-            np.where(l_null | r_null, None, False),  # type: ignore[call-overload]  # numpy stub limitation
+            np.where(l_null | r_null, None, False),  # ty: ignore[no-matching-overload]  # numpy stubs reject None as broadcast scalar
         ),
         dtype=object,
         index=left.index,

--- a/packages/pycypher/src/pycypher/cli/common.py
+++ b/packages/pycypher/src/pycypher/cli/common.py
@@ -32,7 +32,7 @@ try:
     from _duckdb import IOException as DuckDBIOException
 except ImportError:
     # Handle case where DuckDB is not available
-    DuckDBIOException = None  # type: ignore[assignment]  # fallback when duckdb unavailable
+    DuckDBIOException = None  # ty: ignore[invalid-assignment]  # fallback when duckdb unavailable
 
 if TYPE_CHECKING:
     pass
@@ -151,7 +151,9 @@ def load_data_source(
         if DuckDBIOException is not None and isinstance(
             exc, DuckDBIOException
         ):
-            cli_error(translate_duckdb_error(exc, kind, safe_path), exit_code=1)
+            cli_error(
+                translate_duckdb_error(exc, kind, safe_path), exit_code=1
+            )
         # Generic fallback for unexpected errors
         exc_name = type(exc).__name__
         cli_error(

--- a/packages/pycypher/src/pycypher/cli/query.py
+++ b/packages/pycypher/src/pycypher/cli/query.py
@@ -117,12 +117,17 @@ def _explain_query(cypher_query: str) -> None:
 
     click.echo(f"\nParse: {parse_ms:.1f}ms  Convert: {convert_ms:.1f}ms")
     click.echo(f"Root: {type(typed_ast).__name__}")
+    if typed_ast is None:
+        click.echo("\n(empty AST)")
+        return
     click.echo(f"\n{typed_ast.pretty()}")
 
     from pycypher.semantic_validator import SemanticValidator
 
     validator = SemanticValidator()
-    errors = validator.validate(typed_ast)
+    # SemanticValidator.validate accepts a Tree at the type level but
+    # historically operates on any ASTNode root (parse_tree → typed_ast).
+    errors = validator.validate(typed_ast)  # ty: ignore[invalid-argument-type]
     if errors:
         click.echo("\nValidation errors:")
         for err in errors:
@@ -153,7 +158,9 @@ def _profile_query(
         builder.add_entity(label, path, id_col=id_col)
     for spec in relationship:
         rel_type, path, src_col, tgt_col = _parse_rel_arg(spec)
-        builder.add_relationship(rel_type, path, source_col=src_col, target_col=tgt_col)
+        builder.add_relationship(
+            rel_type, path, source_col=src_col, target_col=tgt_col
+        )
 
     ctx = builder.build()
     star = Star(context=ctx)
@@ -294,8 +301,12 @@ def query(
     if profile:
         _profile_query(cypher_query, entity, relationship, parameter)
     else:
-        # Import the original implementation
-        from pycypher.nmetl_cli import query as _original_query
+        # Import the original implementation. The `query` subcommand is
+        # registered dynamically on the `cli` Click group via
+        # _register_query_command(cli), so it appears as a callable click
+        # Command attribute at runtime even though the module has no static
+        # `query` binding.
+        from pycypher.nmetl_cli import query as _original_query  # ty: ignore[unresolved-import]
 
         # Delegate to original implementation
         _original_query(

--- a/packages/pycypher/src/pycypher/cli/security.py
+++ b/packages/pycypher/src/pycypher/cli/security.py
@@ -11,11 +11,15 @@ import re
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import click
 
 from .common import load_config
+
+if TYPE_CHECKING:
+    from pycypher.ingestion.config import PipelineConfig
 
 
 class Severity(StrEnum):
@@ -194,7 +198,7 @@ def _check_query_injection(
         )
 
 
-def scan_config(config: object) -> SecurityReport:
+def scan_config(config: PipelineConfig) -> SecurityReport:
     """Run all security checks against a loaded PipelineConfig.
 
     Args:

--- a/packages/pycypher/src/pycypher/collection_evaluator.py
+++ b/packages/pycypher/src/pycypher/collection_evaluator.py
@@ -279,12 +279,15 @@ class CollectionExpressionEvaluator:
             """
             if c is None:
                 return None
-            s_idx: int | None = int(s) if s is not None else None  # type: ignore[arg-type]  # s is narrowed to non-None
-            e_idx: int | None = int(e) if e is not None else None  # type: ignore[arg-type]  # e is narrowed to non-None
+            # `s`/`e` are typed `object` for the broad input contract; runtime
+            # values are int|float|str (Cypher slice expressions) — int() handles all.
+            s_idx: int | None = int(s) if s is not None else None  # ty: ignore[invalid-argument-type]
+            e_idx: int | None = int(e) if e is not None else None  # ty: ignore[invalid-argument-type]
             if isinstance(c, str):
                 return c[s_idx:e_idx]
             try:
-                sliced = list(c)[s_idx:e_idx]  # type: ignore[arg-type]  # c is not None (guarded above)
+                # `c` is `object` per signature; runtime is iterable (str | list | tuple).
+                sliced = list(c)[s_idx:e_idx]  # ty: ignore[invalid-argument-type]
             except TypeError:
                 if _DEBUG_ENABLED:
                     LOGGER.debug(
@@ -335,6 +338,10 @@ class CollectionExpressionEvaluator:
         from pycypher.binding_frame import BindingFrame
 
         var_name: str = lc.variable.name if lc.variable else "_lc_var"
+        # ListComprehension is constructed with list_expr set to a real
+        # Expression by the parser; the AST's `Expression | None` typing is
+        # for incremental construction.
+        assert lc.list_expr is not None, "list_comprehension missing list_expr"
         list_series: pd.Series = expression_evaluator.evaluate(lc.list_expr)
         n_rows: int = len(list_series)
 
@@ -477,6 +484,11 @@ class CollectionExpressionEvaluator:
         import numpy as np
 
         from pycypher.binding_frame import BindingFrame
+
+        # Quantifier nodes always carry list_expr/where/variable at parse time.
+        assert q.list_expr is not None, "quantifier missing list_expr"
+        assert q.where is not None, "quantifier missing where"
+        assert q.variable is not None, "quantifier missing variable"
 
         # Get the list values to iterate over
         list_values = expression_evaluator.evaluate(q.list_expr)
@@ -622,6 +634,15 @@ class CollectionExpressionEvaluator:
         if _DEBUG_ENABLED:
             LOGGER.debug("collection: reduce  rows=%d", len(self.frame))
         from pycypher.binding_frame import BindingFrame
+
+        # Reduce nodes always carry list_expr/initial/map_expr/accumulator/variable
+        # at parse time; the AST's `... | None` typings are for incremental
+        # construction.
+        assert r.list_expr is not None, "reduce missing list_expr"
+        assert r.initial is not None, "reduce missing initial"
+        assert r.map_expr is not None, "reduce missing map_expr"
+        assert r.accumulator is not None, "reduce missing accumulator"
+        assert r.variable is not None, "reduce missing variable"
 
         # Step 1: Evaluate list_values and initial_value once over the full frame
         list_values = expression_evaluator.evaluate(r.list_expr)
@@ -915,7 +936,9 @@ class CollectionExpressionEvaluator:
                             if entity_id is not None and not pd.isna(
                                 entity_id,
                             ):
-                                props = self.frame.get_all_properties(  # type: ignore[union-attr]  # frame is BindingFrame at runtime
+                                # frame is the BindingFrame implementation at runtime;
+                                # get_all_properties is not on the protocol declaration.
+                                props = self.frame.get_all_properties(  # ty: ignore[unresolved-attribute]
                                     var_name,
                                     entity_id,
                                 )

--- a/packages/pycypher/src/pycypher/comparison_evaluator.py
+++ b/packages/pycypher/src/pycypher/comparison_evaluator.py
@@ -281,6 +281,12 @@ class ComparisonEvaluator:
             )
         # Apply WHEN clauses in reverse so the first clause takes priority
         for clause in reversed(when_clauses):
+            assert clause.result is not None, (
+                "WHEN clause must have a result expression"
+            )
+            assert clause.condition is not None, (
+                "WHEN clause must have a condition expression"
+            )
             then = evaluator.evaluate(clause.result)
 
             if discriminant is not None:

--- a/packages/pycypher/src/pycypher/exceptions/base.py
+++ b/packages/pycypher/src/pycypher/exceptions/base.py
@@ -90,7 +90,7 @@ def _detect_environment() -> str:
     # Jupyter / IPython notebook -- only attempt if already imported
     if "IPython" in sys.modules:
         try:
-            from IPython import get_ipython  # type: ignore[import-untyped]
+            from IPython import get_ipython  # ty: ignore[unresolved-import]  # optional dependency, guarded by sys.modules check + ImportError catch
 
             ipy = get_ipython()
             if ipy is not None and "ZMQInteractiveShell" in type(ipy).__name__:
@@ -120,7 +120,9 @@ def _make_docs_link(cls_name: str) -> DocsLink | None:
     """Build a :class:`DocsLink` for *cls_name*, or ``None`` if unmapped."""
     anchor = _DOCS_ANCHORS.get(cls_name, "")
     if anchor and _DOCS_BASE_URL:
-        return DocsLink(url=f"{_DOCS_BASE_URL}{anchor}", exception_name=cls_name)
+        return DocsLink(
+            url=f"{_DOCS_BASE_URL}{anchor}", exception_name=cls_name
+        )
     return None
 
 

--- a/packages/pycypher/src/pycypher/expression_renderer.py
+++ b/packages/pycypher/src/pycypher/expression_renderer.py
@@ -33,7 +33,34 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pycypher.ast_models import Expression
+    from pycypher.ast_models import (
+        And,
+        Arithmetic,
+        BooleanLiteral,
+        CaseExpression,
+        Comparison,
+        CountStar,
+        Expression,
+        FloatLiteral,
+        FunctionInvocation,
+        IndexLookup,
+        IntegerLiteral,
+        LabelPredicate,
+        ListComprehension,
+        Not,
+        NullCheck,
+        NullLiteral,
+        Or,
+        Parameter,
+        PropertyLookup,
+        Reduce,
+        Slicing,
+        StringLiteral,
+        StringPredicate,
+        Unary,
+        Variable,
+        Xor,
+    )
 
 
 class ExpressionRenderer:
@@ -56,9 +83,17 @@ class ExpressionRenderer:
         :meth:`render` call to avoid import-time dependency on
         :mod:`pycypher.ast_models`.
         """
-        self._dispatch: dict[type, Callable[[Expression], str | None]] | None = None
+        # Dispatch values use Callable[..., str | None] (rather than
+        # Callable[[Expression], ...]) because each handler narrows its
+        # parameter type to the specific AST subclass it expects (e.g.
+        # `_render_variable(self, expr: Variable)`). Function-arg types are
+        # contravariant, so a handler taking `Variable` is not assignable to
+        # `Callable[[Expression], ...]`. The runtime dispatch on
+        # `type(expression)` guarantees the actual arg matches the handler's
+        # narrower parameter type.
+        self._dispatch: dict[type, Callable[..., str | None]] | None = None
 
-    def _build_dispatch(self) -> dict[type, Callable[[Expression], str | None]]:
+    def _build_dispatch(self) -> dict[type, Callable[..., str | None]]:
         """Build the type → handler dispatch table.
 
         Returns:
@@ -121,20 +156,22 @@ class ExpressionRenderer:
             Reduce: self._render_reduce,
         }
 
-    def render(self, expression: Expression) -> str | None:
+    def render(self, expression: Expression | None) -> str | None:
         """Return a short human-readable text for *expression*, or ``None``.
 
         Follows the unqualified-property convention:
         ``PropertyLookup(p, 'name')`` → ``"name"``.
 
         Args:
-            expression: Any Cypher AST expression node.
+            expression: Any Cypher AST expression node, or ``None``.
 
         Returns:
-            A string display name, or ``None`` if no representation is
-            available for the expression type.
+            A string display name, or ``None`` if *expression* is ``None`` or
+            no representation is available for the expression type.
 
         """
+        if expression is None:
+            return None
         if self._dispatch is None:
             self._dispatch = self._build_dispatch()
 
@@ -147,35 +184,35 @@ class ExpressionRenderer:
     # Individual renderers (CC ~2–3 each)
     # ------------------------------------------------------------------
 
-    def _render_variable(self, expr: Expression) -> str:
+    def _render_variable(self, expr: Variable) -> str:
         """Render a :class:`Variable` node as its bare name (e.g. ``"n"``)."""
         return expr.name
 
-    def _render_property_lookup(self, expr: Expression) -> str:
+    def _render_property_lookup(self, expr: PropertyLookup) -> str:
         """Render a :class:`PropertyLookup` as the unqualified property name (e.g. ``"name"``)."""
-        return expr.property
+        return expr.property or ""
 
-    def _render_integer(self, expr: Expression) -> str:
+    def _render_integer(self, expr: IntegerLiteral) -> str:
         """Render an :class:`IntegerLiteral` as its decimal string (e.g. ``"42"``)."""
         return str(expr.value)
 
-    def _render_float(self, expr: Expression) -> str:
+    def _render_float(self, expr: FloatLiteral) -> str:
         """Render a :class:`FloatLiteral` as its decimal string (e.g. ``"3.14"``)."""
         return str(expr.value)
 
-    def _render_string(self, expr: Expression) -> str:
+    def _render_string(self, expr: StringLiteral) -> str:
         """Render a :class:`StringLiteral` as its raw value (e.g. ``"hello"``)."""
         return str(expr.value)
 
-    def _render_boolean(self, expr: Expression) -> str:
+    def _render_boolean(self, expr: BooleanLiteral) -> str:
         """Render a :class:`BooleanLiteral` as Cypher ``"true"`` or ``"false"``."""
         return "true" if expr.value else "false"
 
-    def _render_null(self, expr: Expression) -> str:
+    def _render_null(self, expr: NullLiteral) -> str:
         """Render a :class:`NullLiteral` as the string ``"null"``."""
         return "null"
 
-    def _render_function(self, expr: Expression) -> str:
+    def _render_function(self, expr: FunctionInvocation) -> str:
         """Render a :class:`FunctionInvocation` as ``name(arg1, arg2, ...)``.
 
         Handles both list and dict argument representations. Unrenderable
@@ -189,10 +226,18 @@ class ExpressionRenderer:
             arg_list = raw_args.get("arguments") or raw_args.get("args") or []
         else:
             arg_list = []
-        arg_texts = [self.render(a) or "?" for a in arg_list]
+        # Each `a` is an Expression at runtime (ASTNode is the parent
+        # class in declared types but the call sites only pass Expressions);
+        # render() also accepts None and unhandled types safely.
+        arg_texts = [
+            self.render(a) or "?"  # ty: ignore[invalid-argument-type]
+            for a in arg_list
+        ]
         return f"{fname}({', '.join(arg_texts)})"
 
-    def _render_binary_op(self, expr: Expression) -> str:
+    def _render_binary_op(
+        self, expr: Arithmetic | Comparison | StringPredicate
+    ) -> str:
         """Render a binary operation (``Arithmetic``, ``Comparison``, or ``StringPredicate``).
 
         Produces ``"left op right"`` (e.g. ``"n.age > 18"``).  Shared handler
@@ -202,28 +247,28 @@ class ExpressionRenderer:
         right_text = self.render(expr.right) or "?"
         return f"{left_text} {expr.operator} {right_text}"
 
-    def _render_null_check(self, expr: Expression) -> str:
+    def _render_null_check(self, expr: NullCheck) -> str:
         """Render a :class:`NullCheck` as ``"expr IS NULL"`` or ``"expr IS NOT NULL"``."""
         operand_text = self.render(expr.operand) or "?"
         return f"{operand_text} {expr.operator}"
 
-    def _render_not(self, expr: Expression) -> str:
+    def _render_not(self, expr: Not) -> str:
         """Render a :class:`Not` node as ``"NOT expr"``."""
         operand_text = self.render(expr.operand) or "?"
         return f"NOT {operand_text}"
 
-    def _render_connective(self, expr: Expression) -> str:
+    def _render_connective(self, expr: And | Or | Xor) -> str:
         """Render an :class:`And`, :class:`Or`, or :class:`Xor` as ``"a OP b OP c"``."""
         sep = f" {expr.operator} "
         parts = [self.render(op) or "?" for op in expr.operands]
         return sep.join(parts)
 
-    def _render_label_predicate(self, expr: Expression) -> str:
+    def _render_label_predicate(self, expr: LabelPredicate) -> str:
         """Render a :class:`LabelPredicate` as ``"expr:Label1:Label2"``."""
         operand_text = self.render(expr.operand) or "?"
         return f"{operand_text}:{':'.join(expr.labels)}"
 
-    def _render_unary(self, expr: Expression) -> str | None:
+    def _render_unary(self, expr: Unary) -> str | None:
         """Render a :class:`Unary` node as ``"op expr"`` (e.g. ``"-x"``).
 
         Returns ``None`` if the operand is absent.
@@ -233,28 +278,28 @@ class ExpressionRenderer:
         operand_text = self.render(expr.operand) or "?"
         return f"{expr.operator}{operand_text}"
 
-    def _render_parameter(self, expr: Expression) -> str:
+    def _render_parameter(self, expr: Parameter) -> str:
         """Render a :class:`Parameter` as ``"$name"``."""
         return f"${expr.name}"
 
-    def _render_count_star(self, expr: Expression) -> str:
+    def _render_count_star(self, expr: CountStar) -> str:
         """Render a :class:`CountStar` as the string ``"count(*)"``."""
         return "count(*)"
 
-    def _render_index_lookup(self, expr: Expression) -> str:
+    def _render_index_lookup(self, expr: IndexLookup) -> str:
         """Render an :class:`IndexLookup` as ``"expr[index]"``."""
         expr_text = self.render(expr.expression) or "?"
         idx_text = self.render(expr.index) or "?"
         return f"{expr_text}[{idx_text}]"
 
-    def _render_slicing(self, expr: Expression) -> str:
+    def _render_slicing(self, expr: Slicing) -> str:
         """Render a :class:`Slicing` as ``"expr[start..end]"`` with optional bounds."""
         expr_text = self.render(expr.expression) or "?"
         start_text = self.render(expr.start) if expr.start is not None else ""
         end_text = self.render(expr.end) if expr.end is not None else ""
         return f"{expr_text}[{start_text}..{end_text}]"
 
-    def _render_list_comprehension(self, expr: Expression) -> str:
+    def _render_list_comprehension(self, expr: ListComprehension) -> str:
         """Render a :class:`ListComprehension` as ``"[var IN list | map_expr]"``.
 
         Omits the ``| map_expr`` portion when no mapping expression is present.
@@ -268,11 +313,11 @@ class ExpressionRenderer:
             return f"[{var_text} IN {list_text} | {map_text}]"
         return f"[{var_text} IN {list_text}]"
 
-    def _render_case(self, expr: Expression) -> str:
+    def _render_case(self, expr: CaseExpression) -> str:
         """Render a :class:`CaseExpression` as the short label ``"case"``."""
         return "case"
 
-    def _render_reduce(self, expr: Expression) -> str:
+    def _render_reduce(self, expr: Reduce) -> str:
         """Render a :class:`Reduce` expression as ``"reduce(acc, list)"``."""
         acc_text = expr.accumulator.name if expr.accumulator else "?"
         list_text = self.render(expr.list_expr) or "?"

--- a/packages/pycypher/src/pycypher/feedback_collector.py
+++ b/packages/pycypher/src/pycypher/feedback_collector.py
@@ -410,7 +410,9 @@ class PredicateSelectivityTracker:
             for i in range(len(predicates)):
                 for j in range(i + 1, len(predicates)):
                     corr = self.get_correlation_factor(
-                        entity_type, predicates[i], predicates[j],
+                        entity_type,
+                        predicates[i],
+                        predicates[j],
                     )
                     if corr is not None:
                         result *= corr
@@ -462,7 +464,9 @@ class PredicateSelectivityTracker:
             for i in range(len(predicates)):
                 for j in range(i + 1, len(predicates)):
                     key = self._correlation_key(
-                        entity_type, predicates[i], predicates[j],
+                        entity_type,
+                        predicates[i],
+                        predicates[j],
                     )
                     with self._lock:
                         if key not in self._correlation_history:
@@ -477,8 +481,7 @@ class PredicateSelectivityTracker:
 
                         prev = self._correlation_ema[key]
                         self._correlation_ema[key] = (
-                            _EMA_ALPHA * corr_factor
-                            + (1 - _EMA_ALPHA) * prev
+                            _EMA_ALPHA * corr_factor + (1 - _EMA_ALPHA) * prev
                         )
 
     def get_correlation_factor(
@@ -625,7 +628,7 @@ class JoinPerformanceTracker:
         if not candidates:
             return None
 
-        best = min(candidates, key=candidates.get)  # type: ignore[arg-type]
+        best = min(candidates, key=candidates.get)  # ty: ignore[no-matching-overload]  # dict.get matches min's key signature at runtime; stubs are too strict
         LOGGER.debug(
             "Join performance tracker: best strategy for %s is %s (avg %.1fms)",
             bucket_key,
@@ -798,7 +801,8 @@ class PlanVersionTracker:
             return best
 
     def get_history(
-        self, fingerprint: QueryFingerprint,
+        self,
+        fingerprint: QueryFingerprint,
     ) -> list[dict[str, Any]]:
         """Get full version history for a fingerprint."""
         with self._lock:
@@ -818,7 +822,9 @@ class PlanVersionTracker:
             ]
 
     def detect_regression(
-        self, fingerprint: QueryFingerprint, version: int,
+        self,
+        fingerprint: QueryFingerprint,
+        version: int,
     ) -> bool:
         """Detect if a plan version is a regression vs the previous best.
 
@@ -839,7 +845,9 @@ class PlanVersionTracker:
             if target is None or not target.execution_times:
                 return False
 
-            target_avg = sum(target.execution_times) / len(target.execution_times)
+            target_avg = sum(target.execution_times) / len(
+                target.execution_times
+            )
 
             # Find best average among other versions
             best_other_avg: float = float("inf")

--- a/packages/pycypher/src/pycypher/frame_joiner.py
+++ b/packages/pycypher/src/pycypher/frame_joiner.py
@@ -22,7 +22,7 @@ import pandas as pd
 from shared.logger import LOGGER
 
 if TYPE_CHECKING:
-    from pycypher.ast_models import ASTNode, Match
+    from pycypher.ast_models import ASTNode, Expression, Match
     from pycypher.binding_frame import BindingFrame
     from pycypher.query_planner import JoinPlan
     from pycypher.relational_models import Context
@@ -72,7 +72,7 @@ class FrameJoiner:
         frame_a: BindingFrame,
         frame_b: BindingFrame,
         *,
-        join_plan: object | None = None,
+        join_plan: JoinPlan | None = None,
     ) -> BindingFrame:
         """Join two BindingFrame objects.
 
@@ -143,7 +143,7 @@ class FrameJoiner:
         self,
         current_frame: BindingFrame,
         match_frame: BindingFrame,
-        where_clause: ASTNode | None = None,
+        where_clause: Expression | None = None,
     ) -> BindingFrame:
         """Merge a new MATCH frame into the existing execution frame.
 
@@ -234,9 +234,20 @@ class FrameJoiner:
             left_col = current_frame.bindings[var]
             right_col = match_frame.bindings[var]
             if left_col.dtype != right_col.dtype:
-                common_dtype = pd.api.types.find_common_type(
-                    [left_col.dtype, right_col.dtype]
-                )
+                # pd.api.types.find_common_type was removed; use numpy directly.
+                # Object dtype is the safe lowest common denominator when
+                # one side is object — coerce both to object.
+                import numpy as np
+
+                if (
+                    left_col.dtype == object  # noqa: E721
+                    or right_col.dtype == object  # noqa: E721
+                ):
+                    common_dtype = np.dtype("object")
+                else:
+                    common_dtype = np.promote_types(
+                        left_col.dtype, right_col.dtype
+                    )
                 current_frame.bindings[var] = left_col.astype(common_dtype)
                 match_frame.bindings[var] = right_col.astype(common_dtype)
             return current_frame.left_join(match_frame, var, var)
@@ -263,6 +274,7 @@ class FrameJoiner:
         from pycypher.binding_frame import BindingFrame
 
         new_var_types: dict[str, str] = {}
+        assert clause.pattern is not None, "OPTIONAL MATCH must have a pattern"
         for path in clause.pattern.paths:
             for el in path.elements:
                 if (
@@ -320,7 +332,7 @@ class FrameJoiner:
 # ---------------------------------------------------------------------------
 
 
-def _extract_conjuncts(predicate: ASTNode) -> list[ASTNode]:
+def _extract_conjuncts(predicate: Expression) -> list[Expression]:
     """Split an AND-connected predicate into its conjunct list.
 
     Non-AND predicates are returned as a single-element list.
@@ -328,14 +340,14 @@ def _extract_conjuncts(predicate: ASTNode) -> list[ASTNode]:
     from pycypher.ast_models import And
 
     if isinstance(predicate, And) and predicate.operands:
-        conjuncts: list[ASTNode] = []
+        conjuncts: list[Expression] = []
         for op in predicate.operands:
             conjuncts.extend(_extract_conjuncts(op))
         return conjuncts
     return [predicate]
 
 
-def _rebuild_and(conjuncts: list[ASTNode]) -> ASTNode | None:
+def _rebuild_and(conjuncts: list[Expression]) -> Expression | None:
     """Rebuild an AND node from a list of conjuncts, or return None if empty."""
     if not conjuncts:
         return None
@@ -356,10 +368,10 @@ def _predicate_variables(predicate: ASTNode) -> set[str]:
 
 
 def _split_pushdown_predicates(
-    where_clause: ASTNode,
+    where_clause: Expression,
     match_vars: set[str],
     current_vars: set[str],
-) -> tuple[ASTNode | None, ASTNode | None]:
+) -> tuple[Expression | None, Expression | None]:
     """Split a WHERE clause into pre-join and post-join predicates.
 
     Conjuncts whose variables are all in *match_vars* (and NOT in

--- a/packages/pycypher/src/pycypher/grammar_rule_mixins/expressions.py
+++ b/packages/pycypher/src/pycypher/grammar_rule_mixins/expressions.py
@@ -637,7 +637,7 @@ class ExpressionRulesMixin:
                 first_alt = arg.children[0]
                 if isinstance(first_alt, Tree):
                     resolved.append(
-                        self.node_pattern(list(first_alt.children)),  # type: ignore[attr-defined]  # mixin; method from composing class
+                        self.node_pattern(list(first_alt.children)),  # ty: ignore[unresolved-attribute]  # mixin; node_pattern is provided by the composing class
                     )
                 else:
                     resolved.append(self.node_pattern([]))

--- a/packages/pycypher/src/pycypher/ingestion/data_preview.py
+++ b/packages/pycypher/src/pycypher/ingestion/data_preview.py
@@ -173,7 +173,9 @@ class DataSampler:
         raise ValueError(msg)
 
     def _cache_key(self, n: int, strategy: SamplingStrategy) -> str:
-        source_id = self._source if isinstance(self._source, str) else id(self._source)
+        source_id = (
+            self._source if isinstance(self._source, str) else id(self._source)
+        )
         return f"{source_id}:{n}:{strategy.value}"
 
     # -- public API ---------------------------------------------------------
@@ -244,7 +246,9 @@ class DataSampler:
 
         with duckdb.connect() as con:
             con.execute(f"CREATE VIEW source AS SELECT * FROM {read_fn}")  # nosec B608
-            total = con.execute("SELECT COUNT(*) FROM source").fetchone()[0]
+            count_row = con.execute("SELECT COUNT(*) FROM source").fetchone()
+            assert count_row is not None  # COUNT(*) always returns a row
+            total = count_row[0]
 
             if n >= total:
                 return con.execute("SELECT * FROM source").to_arrow_table()
@@ -293,7 +297,9 @@ class DataSampler:
             col_names = [row[0] for row in desc]
             col_types = [row[1] for row in desc]
             # Get row count
-            row_count = con.execute("SELECT COUNT(*) FROM source").fetchone()[0]
+            count_row = con.execute("SELECT COUNT(*) FROM source").fetchone()
+            assert count_row is not None  # COUNT(*) always returns a row
+            row_count = count_row[0]
             return SchemaInfo(
                 column_names=col_names,
                 column_types=col_types,
@@ -333,6 +339,7 @@ class DataSampler:
                 f'MAX("{column}") AS max_val '
                 f"FROM source"
             ).fetchone()
+            assert row is not None  # aggregation always returns a row
             col_idx = table.schema.get_field_index(column)
             dtype = str(table.schema.types[col_idx])
             return ColumnStats(
@@ -368,6 +375,7 @@ class DataSampler:
                 f'MAX("{column}") AS max_val '
                 f"FROM source"
             ).fetchone()
+            assert row is not None  # aggregation always returns a row
             return ColumnStats(
                 name=column,
                 dtype=dtype,
@@ -402,7 +410,9 @@ class QueryTester:
 
     def __init__(self, sample_size: int | None = None) -> None:
         self._sample_size = sample_size
-        self._entities: list[tuple[str, str | pd.DataFrame | pa.Table, str | None]] = []
+        self._entities: list[
+            tuple[str, str | pd.DataFrame | pa.Table, str | None]
+        ] = []
         self._relationships: list[
             tuple[str, str | pd.DataFrame | pa.Table, str, str, str | None]
         ] = []
@@ -448,7 +458,9 @@ class QueryTester:
         Returns:
             ``self`` for chaining.
         """
-        self._relationships.append((rel_type, source, source_col, target_col, id_col))
+        self._relationships.append(
+            (rel_type, source, source_col, target_col, id_col)
+        )
         return self
 
     def run(self, cypher: str) -> QueryResult:
@@ -475,7 +487,13 @@ class QueryTester:
                 else:
                     builder.add_entity(entity_type, source, id_col=id_col)
 
-            for rel_type, source, source_col, target_col, id_col in self._relationships:
+            for (
+                rel_type,
+                source,
+                source_col,
+                target_col,
+                id_col,
+            ) in self._relationships:
                 if self._sample_size is not None:
                     sampler = DataSampler(source)
                     sampled = sampler.sample(

--- a/packages/pycypher/src/pycypher/ingestion/introspector.py
+++ b/packages/pycypher/src/pycypher/ingestion/introspector.py
@@ -20,9 +20,9 @@ from typing import Any
 import pandas as pd
 import pyarrow as pa
 
-LOGGER = logging.getLogger(__name__)
-
 from pycypher.ingestion.data_sources import data_source_from_uri
+
+LOGGER = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -105,10 +105,7 @@ class DataSourceIntrospector:
             A :class:`SchemaInfo` with column names, types, and row count.
         """
         table = self._load()
-        columns = [
-            {"name": f.name, "type": str(f.type)}
-            for f in table.schema
-        ]
+        columns = [{"name": f.name, "type": str(f.type)} for f in table.schema]
         return SchemaInfo(columns=columns, row_count=len(table))
 
     # -- Sampling -----------------------------------------------------------
@@ -147,7 +144,8 @@ class DataSourceIntrospector:
                 unique_count = len(unique_values)
             except Exception:  # noqa: BLE001 — best-effort stats
                 LOGGER.debug(
-                    "Failed to compute unique count for column %r", f.name,
+                    "Failed to compute unique count for column %r",
+                    f.name,
                     exc_info=True,
                 )
                 unique_count = 0
@@ -160,11 +158,12 @@ class DataSourceIntrospector:
 
                 non_null = col.drop_null()
                 if len(non_null) > 0 and _is_ordered_type(f.type):
-                    min_val = pc.min(non_null).as_py()
-                    max_val = pc.max(non_null).as_py()
+                    min_val = pc.min(non_null).as_py()  # ty: ignore[unresolved-attribute]  # pc.min exists at runtime; pyarrow stubs miss it
+                    max_val = pc.max(non_null).as_py()  # ty: ignore[unresolved-attribute]  # pc.max exists at runtime; pyarrow stubs miss it
             except Exception:  # noqa: BLE001 — best-effort stats
                 LOGGER.debug(
-                    "Failed to compute min/max for column %r", f.name,
+                    "Failed to compute min/max for column %r",
+                    f.name,
                     exc_info=True,
                 )
 

--- a/packages/pycypher/src/pycypher/ingestion/pipeline_builder.py
+++ b/packages/pycypher/src/pycypher/ingestion/pipeline_builder.py
@@ -307,7 +307,9 @@ class PipelineBuilder:
         msg = f"Relationship source {source_id!r} not found."
         raise KeyError(msg)
 
-    def update_relationship_source(self, source_id: str, **kwargs: Any) -> None:
+    def update_relationship_source(
+        self, source_id: str, **kwargs: Any
+    ) -> None:
         """Update fields of an existing relationship source.
 
         Raises:
@@ -413,8 +415,10 @@ class PipelineBuilder:
                 details={"query_id": query_id, "uri": uri},
             )
         )
+        # Pydantic validates raw str → OutputFormat enum at runtime; the
+        # public API takes a plain str for ergonomic CLI/YAML use.
         self._config.output.append(
-            OutputConfig(query_id=query_id, uri=uri, format=format)
+            OutputConfig(query_id=query_id, uri=uri, format=format)  # ty: ignore[invalid-argument-type]  # str → OutputFormat coerced by pydantic
         )
 
     def remove_output(self, query_id: str, uri: str) -> None:
@@ -500,18 +504,10 @@ class PipelineBuilder:
             added_relationships, removed_relationships,
             added_queries, removed_queries.
         """
-        prev_entity_ids = {
-            s.id for s in previous.config.sources.entities
-        }
-        curr_entity_ids = {
-            s.id for s in self._config.sources.entities
-        }
-        prev_rel_ids = {
-            s.id for s in previous.config.sources.relationships
-        }
-        curr_rel_ids = {
-            s.id for s in self._config.sources.relationships
-        }
+        prev_entity_ids = {s.id for s in previous.config.sources.entities}
+        curr_entity_ids = {s.id for s in self._config.sources.entities}
+        prev_rel_ids = {s.id for s in previous.config.sources.relationships}
+        curr_rel_ids = {s.id for s in self._config.sources.relationships}
         prev_query_ids = {q.id for q in previous.config.queries}
         curr_query_ids = {q.id for q in self._config.queries}
 
@@ -572,7 +568,9 @@ class PipelineBuilder:
 
     def to_yaml(self) -> str:
         """Serialize the current config to a YAML string."""
-        data = self._config.model_dump(exclude_none=True, exclude_defaults=False)
+        data = self._config.model_dump(
+            exclude_none=True, exclude_defaults=False
+        )
         return yaml.dump(data, default_flow_style=False, sort_keys=False)
 
     def save(self, path: str | Path) -> None:

--- a/packages/pycypher/src/pycypher/lazy_eval.py
+++ b/packages/pycypher/src/pycypher/lazy_eval.py
@@ -742,7 +742,7 @@ def _extract_clause_variables(clause: Any) -> set[str]:
     return refs
 
 
-def compute_live_columns(clauses: list[Any]) -> list[set[str] | None]:
+def compute_live_columns(clauses: list[Any]) -> list[frozenset[str] | None]:
     """Compute the set of live (needed) columns after each clause.
 
     For each clause index ``i``, returns the set of variable names that are
@@ -773,7 +773,7 @@ def compute_live_columns(clauses: list[Any]) -> list[set[str] | None]:
     )
 
     n = len(clauses)
-    result: list[set[str] | None] = [None] * n
+    result: list[frozenset[str] | None] = [None] * n
 
     if n == 0:
         return result

--- a/packages/pycypher/src/pycypher/mutation_engine.py
+++ b/packages/pycypher/src/pycypher/mutation_engine.py
@@ -153,6 +153,12 @@ class MutationEngine:
                 # SET p:Label — label assignment; no DataFrame property to update
                 continue
 
+            # Property-targeted SET items always carry a variable target;
+            # only label-only SetItem (filtered above) leaves item.variable None.
+            assert item.variable is not None, (
+                "SET item with property must have variable"
+            )
+
             if prop in ("*", "*+"):
                 if isinstance(expr, MapLiteral):
                     # Batch all map literal properties into a single merge pass.
@@ -703,7 +709,8 @@ class MutationEngine:
                     backend = self._backend
                     if backend is not None:
                         self.context._shadow_rels[rel_type] = backend.filter(
-                            rel_df, keep_mask,
+                            rel_df,
+                            keep_mask,
                         )
                     else:
                         self.context._shadow_rels[rel_type] = rel_df[
@@ -801,7 +808,10 @@ class MutationEngine:
                 entity_type="mixed",
                 affected_count=len(match_frame.bindings),
                 elapsed_s=time.perf_counter() - t0,
-                details={"action": "match", "on_match_set": bool(clause.on_match)},
+                details={
+                    "action": "match",
+                    "on_match_set": bool(clause.on_match),
+                },
             )
             if current_frame is None:
                 return match_frame
@@ -1022,6 +1032,10 @@ class MutationEngine:
         )
         for item in remove_clause.items:
             if item.property is not None:
+                # Property-targeted REMOVE always has a variable target.
+                assert item.variable is not None, (
+                    "REMOVE item with property must have variable"
+                )
                 null_values = _null_series(len(frame))
                 frame.mutate(item.variable.name, item.property, null_values)
         elapsed = time.perf_counter() - t0
@@ -1110,7 +1124,12 @@ class MutationEngine:
                 alias = item.alias or source_key
                 if alias is None:
                     continue
-                columns[alias] = [row.get(source_key, None) for row in rows]
+                if source_key is None:
+                    # alias was specified explicitly but variable target is
+                    # absent — column is null for every row.
+                    columns[alias] = [None for _ in rows]
+                else:
+                    columns[alias] = [row.get(source_key) for row in rows]
             proc_df = pd.DataFrame(columns)
 
         return BindingFrame(

--- a/packages/pycypher/src/pycypher/nmetl_cli.py
+++ b/packages/pycypher/src/pycypher/nmetl_cli.py
@@ -51,7 +51,7 @@ try:
     from _duckdb import IOException as DuckDBIOException
 except ImportError:
     # Handle case where DuckDB is not available
-    DuckDBIOException = None  # type: ignore[assignment]  # fallback when duckdb unavailable
+    DuckDBIOException = None  # ty: ignore[invalid-assignment]  # fallback when duckdb unavailable
 
 if TYPE_CHECKING:
     pass
@@ -864,7 +864,7 @@ def parse(cypher_query: str, *, as_json: bool, run_validation: bool) -> None:
 # Query sub-command (extracted to _cli_query.py for maintainability)
 # ---------------------------------------------------------------------------
 
-from pycypher._cli_query import (
+from pycypher._cli_query import (  # noqa: E402  # avoiding circular import via _cli_query
     register as _register_query_command,
 )
 

--- a/packages/pycypher/src/pycypher/pattern_matcher.py
+++ b/packages/pycypher/src/pycypher/pattern_matcher.py
@@ -700,6 +700,13 @@ class PatternMatcher:
         """
         anon_counter: list[int] = [0]
         pattern = match_clause.pattern
+        if pattern is None:
+            from pycypher.exceptions import PatternComprehensionError
+
+            raise PatternComprehensionError(
+                "MATCH clause has no pattern. "
+                "Provide at least one pattern, e.g. MATCH (n:Person).",
+            )
 
         frames = [
             self.pattern_path_to_binding_frame(

--- a/packages/pycypher/src/pycypher/query_optimizer.py
+++ b/packages/pycypher/src/pycypher/query_optimizer.py
@@ -476,7 +476,8 @@ class JoinReorderingRule(OptimizationRule):
                     cardinality *= 100  # Unknown relationship default
 
         # Apply WHERE selectivity using column statistics if available
-        if getattr(match, "where", None) is not None:
+        match_where = getattr(match, "where", None)
+        if match_where is not None:
             try:
                 # Build a minimal Query wrapper to use QueryPlanAnalyzer
                 from pycypher.query_planner import QueryPlanAnalyzer
@@ -484,10 +485,15 @@ class JoinReorderingRule(OptimizationRule):
                 dummy_query = Query(clauses=[match])
                 analyzer = QueryPlanAnalyzer(dummy_query, context)
                 selectivity = analyzer.estimate_predicate_selectivity(
-                    match.where,
+                    match_where,
                 )
                 cardinality = max(1, int(cardinality * selectivity))
-            except (AttributeError, TypeError, ValueError, KeyError) as _sel_exc:
+            except (
+                AttributeError,
+                TypeError,
+                ValueError,
+                KeyError,
+            ) as _sel_exc:
                 LOGGER.debug(
                     "Failed to estimate WHERE selectivity; falling back to 0.33: %s",
                     _sel_exc,

--- a/packages/pycypher/src/pycypher/repl.py
+++ b/packages/pycypher/src/pycypher/repl.py
@@ -332,13 +332,18 @@ class CypherRepl(cmd.Cmd):
                 f"\nParse: {parse_ms:.1f}ms  Convert: {convert_ms:.1f}ms"
             )
             click.echo(f"Root: {type(typed_ast).__name__}")
+            if typed_ast is None:
+                click.echo("\n(empty AST)")
+                return
             click.echo(f"\n{typed_ast.pretty()}")
 
             # Show semantic validation
             from pycypher.semantic_validator import SemanticValidator
 
             validator = SemanticValidator()
-            errors = validator.validate(typed_ast)
+            # SemanticValidator.validate accepts a Tree at the type level but
+            # historically operates on any ASTNode root.
+            errors = validator.validate(typed_ast)  # ty: ignore[invalid-argument-type]
             if errors:
                 click.echo("\nValidation errors:")
                 for err in errors:

--- a/packages/pycypher/src/pycypher/scalar_function_evaluator.py
+++ b/packages/pycypher/src/pycypher/scalar_function_evaluator.py
@@ -494,7 +494,7 @@ class ScalarFunctionEvaluator:
             _is_null_literal = len(_non_null) == 0 and _probe.dtype == object
             if _is_list_arg or _is_null_literal:
                 func_meta = (
-                    expression_evaluator.scalar_registry._functions.get(
+                    expression_evaluator.scalar_registry._functions.get(  # ty: ignore[unresolved-attribute]  # scalar_registry attached on concrete BindingExpressionEvaluator, not on the protocol
                         name_lower,
                     )
                 )
@@ -557,7 +557,7 @@ class ScalarFunctionEvaluator:
         if not arg_series:
             n = len(self.frame)
             dummy = pd.Series(range(n), dtype=int)
-            func_meta = expression_evaluator.scalar_registry._functions.get(
+            func_meta = expression_evaluator.scalar_registry._functions.get(  # ty: ignore[unresolved-attribute]  # scalar_registry attached on concrete BindingExpressionEvaluator, not on the protocol
                 name.lower(),
             )
             if func_meta is not None and func_meta.max_args == 0:
@@ -570,7 +570,7 @@ class ScalarFunctionEvaluator:
             LOGGER.debug(
                 msg=f"ScalarFunctionEvaluator: calling scalar '{name}' with {len(arg_series)} args",
             )
-        return expression_evaluator.scalar_registry.execute(name, arg_series)
+        return expression_evaluator.scalar_registry.execute(name, arg_series)  # ty: ignore[unresolved-attribute]  # scalar_registry attached on concrete BindingExpressionEvaluator, not on the protocol
 
 
 # Module-level O(1) dispatch table for special-case scalar functions.

--- a/packages/pycypher/src/pycypher/scalar_functions/conversion_functions.py
+++ b/packages/pycypher/src/pycypher/scalar_functions/conversion_functions.py
@@ -284,7 +284,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
             return s
 
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result
 
         # Convert all non-null values to string and normalize (vectorized)

--- a/packages/pycypher/src/pycypher/scalar_functions/extended_string_functions.py
+++ b/packages/pycypher/src/pycypher/scalar_functions/extended_string_functions.py
@@ -296,7 +296,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
             return s
 
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result
 
         # Convert non-null values to string (vectorized)
@@ -375,7 +375,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
 
         # Handle nulls first
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result
 
         s_str = nr.non_null_vals.astype(str)
@@ -590,7 +590,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
                 return None
             sv = str(val)
             try:
-                pos = int(i)  # type: ignore[arg-type]
+                pos = int(i)  # ty: ignore[invalid-argument-type]  # i is numeric at runtime, guarded above
             except (TypeError, ValueError):
                 return None
             if pos < 0 or pos >= len(sv):
@@ -673,7 +673,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
             if _is_null(v) or _is_null(i):
                 return None
             s_str = str(v)
-            i_int = int(i)  # type: ignore[arg-type]  # guarded by _is_null above
+            i_int = int(i)  # ty: ignore[invalid-argument-type]  # guarded by _is_null above
             if i_int < 0 or i_int >= len(s_str):
                 return None
             return ord(s_str[i_int])
@@ -700,7 +700,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
                     str_lengths = s_str.str.len()
                     valid_bounds_mask = (i_int >= 0) & (i_int < str_lengths)
 
-                    if valid_bounds_mask.any():  # type: ignore[union-attr]  # pandas Series, not bool
+                    if valid_bounds_mask.any():  # ty: ignore[unresolved-attribute]  # pandas Series, not bool
                         # Extract characters at the specified index
                         valid_strings = s_str[valid_bounds_mask]
 
@@ -795,7 +795,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
             s_str = str(v)
             if f == "NFKCCaseFold":
                 return unicodedata.normalize("NFKC", s_str).casefold()
-            return unicodedata.normalize(f, s_str)  # type: ignore[arg-type]  # validated by _VALID_FORMS
+            return unicodedata.normalize(f, s_str)  # ty: ignore[invalid-argument-type]  # validated by _VALID_FORMS
 
         if form is None:
             # No form argument — use NFC default (VECTORIZED)

--- a/packages/pycypher/src/pycypher/scalar_functions/list_functions.py
+++ b/packages/pycypher/src/pycypher/scalar_functions/list_functions.py
@@ -44,7 +44,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
         """Wrap scalar in a list, or return list unchanged; null → null."""
         # Further vectorized implementation eliminating remaining .apply() anti-patterns
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result
 
         # Create mask for list types using vectorized operations
@@ -89,7 +89,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
         """
         # Vectorized implementation replacing .apply(_get_head) anti-pattern
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result
 
         list_indices = []
@@ -127,7 +127,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
         """
         # Vectorized implementation replacing .apply(_get_last) anti-pattern
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result
 
         list_indices = []
@@ -165,7 +165,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
         """
         # Vectorized implementation replacing .apply(_get_tail) anti-pattern
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result
 
         list_indices = []
@@ -492,7 +492,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
         """
         # Vectorized implementation replacing .apply(_sort_one) anti-pattern
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result
 
         list_indices = []
@@ -536,7 +536,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
         """
         # Vectorized implementation replacing .apply(_flatten_one) anti-pattern
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result
 
         list_indices = []
@@ -573,7 +573,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
         """Apply toString to each element of a list (null-safe)."""
         # Vectorized implementation eliminating .apply() anti-pattern
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result
 
         list_indices = []
@@ -612,7 +612,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
     def _to_integer_list(s: pd.Series) -> pd.Series:
         """Apply toInteger to each element of a list (null-safe)."""
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result
 
         def _cvt(v: object) -> object:
@@ -652,7 +652,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
     def _to_float_list(s: pd.Series) -> pd.Series:
         """Apply toFloat to each element of a list (null-safe)."""
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result
 
         def _cvt(v: object) -> object:
@@ -695,7 +695,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
     def _to_boolean_list(s: pd.Series) -> pd.Series:
         """Apply toBoolean to each element of a list (null-safe)."""
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result
 
         def _cvt(v: object) -> object:

--- a/packages/pycypher/src/pycypher/scalar_functions/math_functions.py
+++ b/packages/pycypher/src/pycypher/scalar_functions/math_functions.py
@@ -174,7 +174,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
 
         # Vectorized implementation eliminating .apply() anti-pattern
         nr = _init_null_result(s)
-        if nr.all_null:
+        if nr.non_null_vals is None:
             return nr.result.astype("float64")
 
         try:

--- a/packages/pycypher/src/pycypher/scalar_functions/temporal_functions.py
+++ b/packages/pycypher/src/pycypher/scalar_functions/temporal_functions.py
@@ -90,7 +90,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
         except (ValueError, TypeError):
             # Fallback for complex cases
             nr = _init_null_result(s)
-            if nr.all_null:
+            if nr.non_null_vals is None:
                 return nr.result
 
             parsed_values = []
@@ -174,7 +174,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
         except (ValueError, TypeError):
             # Fallback for complex cases
             nr = _init_null_result(s)
-            if nr.all_null:
+            if nr.non_null_vals is None:
                 return nr.result
 
             parsed_values = []
@@ -277,7 +277,7 @@ def register(registry: ScalarFunctionRegistry) -> None:
                 return None
             # Map form: {"years": 1, "days": 3, ...}
             if isinstance(val, dict):
-                return {k: int(val.get(k, 0)) for k in _COMPONENT_KEYS}  # type: ignore[arg-type]  # narrowed by isinstance
+                return {k: int(val.get(k, 0)) for k in _COMPONENT_KEYS}  # ty: ignore[no-matching-overload]  # dict keys are runtime-checked
             # ISO 8601 string form
             sv = str(val)
             m = _DURATION_RE.match(sv)

--- a/packages/pycypher/src/pycypher/sinks/neo4j.py
+++ b/packages/pycypher/src/pycypher/sinks/neo4j.py
@@ -707,7 +707,7 @@ class Neo4jSink:
                 if not rows:
                     continue
                 try:
-                    session.run(cypher, rows=rows)  # type: ignore[arg-type]  # neo4j stub expects LiteralString
+                    session.run(cypher, rows=rows)  # ty: ignore[invalid-argument-type]  # neo4j stub expects LiteralString; cypher is constructed at runtime
                     total += len(rows)
                 except Exception:  # noqa: BLE001 — log batch details before re-raising
                     # SECURITY: Log only the keys of the first row, not the

--- a/packages/pycypher/src/pycypher/variable_manager.py
+++ b/packages/pycypher/src/pycypher/variable_manager.py
@@ -55,7 +55,7 @@ class VariableManager:
 
         """
         _t0 = time.perf_counter()
-        variables = {v.name for v in node.find_all(Variable)}  # type: ignore[union-attr]  # find_all(Variable) returns Variable instances
+        variables = {v.name for v in node.find_all(Variable)}  # ty: ignore[unresolved-attribute]  # find_all(Variable) returns Variable instances; ASTNode return type is too loose
         LOGGER.debug(
             "collect_variables: found=%d  elapsed=%.3fms",
             len(variables),

--- a/packages/shared/src/shared/dashboard.py
+++ b/packages/shared/src/shared/dashboard.py
@@ -74,11 +74,7 @@ class DashboardData:
     def trend(self, metric: str) -> list[float]:
         """Return time-series values for *metric* across all snapshots."""
         with self._lock:
-            return [
-                snap[metric]
-                for snap in self._history
-                if metric in snap
-            ]
+            return [snap[metric] for snap in self._history if metric in snap]
 
     def to_json(self) -> str:
         """Serialize history and timestamps to JSON."""
@@ -108,9 +104,7 @@ def render_dashboard_html(data: DashboardData) -> str:
         for key, value in sorted(latest.items()):
             esc_key = html.escape(str(key))
             esc_val = html.escape(f"{value}")
-            metric_rows += (
-                f"<tr><td>{esc_key}</td><td>{esc_val}</td></tr>\n"
-            )
+            metric_rows += f"<tr><td>{esc_key}</td><td>{esc_val}</td></tr>\n"
 
     # Build trend data for charting.
     trend_keys = []
@@ -153,28 +147,36 @@ def render_dashboard_html(data: DashboardData) -> str:
 <h1>PyCypher Performance Dashboard</h1>
 <p class="subtitle">Real-time query performance monitoring</p>
 <p class="refresh">Snapshots: {len(history)} | Last update: {
-    time.strftime('%H:%M:%S', time.localtime(timestamps[-1]))
-    if timestamps else 'N/A'
-}</p>
+        time.strftime("%H:%M:%S", time.localtime(timestamps[-1]))
+        if timestamps
+        else "N/A"
+    }</p>
 
 <div class="grid">
   <div class="card">
     <h3>Latency p50</h3>
-    <div class="value">{latest.get('timing_p50_ms', 'N/A') if latest else 'N/A'} ms</div>
+    <div class="value">{
+        latest.get("timing_p50_ms", "N/A") if latest else "N/A"
+    } ms</div>
   </div>
   <div class="card">
     <h3>Latency p90</h3>
-    <div class="value">{latest.get('timing_p90_ms', 'N/A') if latest else 'N/A'} ms</div>
+    <div class="value">{
+        latest.get("timing_p90_ms", "N/A") if latest else "N/A"
+    } ms</div>
   </div>
   <div class="card">
     <h3>Total Queries</h3>
-    <div class="value">{latest.get('total_queries', 'N/A') if latest else 'N/A'}</div>
+    <div class="value">{
+        latest.get("total_queries", "N/A") if latest else "N/A"
+    }</div>
   </div>
   <div class="card">
     <h3>Error Rate</h3>
     <div class="value">{
         f"{latest.get('error_rate', 0) * 100:.1f}%"
-        if latest and 'error_rate' in latest else 'N/A'
+        if latest and "error_rate" in latest
+        else "N/A"
     }</div>
   </div>
 </div>
@@ -183,20 +185,27 @@ def render_dashboard_html(data: DashboardData) -> str:
   <h3>Current Metrics</h3>
   <table>
     <thead><tr><th>Metric</th><th>Value</th></tr></thead>
-    <tbody>{metric_rows if metric_rows else '<tr><td colspan="2">No data</td></tr>'}
+    <tbody>{
+        metric_rows if metric_rows else '<tr><td colspan="2">No data</td></tr>'
+    }
     </tbody>
   </table>
 </div>
 
 <div class="grid">
-{"".join(f'''
+{
+        "".join(
+            f'''
   <div class="card">
     <h3>{html.escape(key)}</h3>
     <div class="chart-container">
       <canvas id="chart-{html.escape(key)}" width="300" height="120"></canvas>
     </div>
   </div>
-''' for key in trend_json)}
+'''
+            for key in trend_json
+        )
+    }
 </div>
 
 <script>
@@ -237,8 +246,11 @@ class _DashboardHandler(http.server.BaseHTTPRequestHandler):
     dashboard_data: DashboardData
 
     def do_GET(self) -> None:  # noqa: N802
+        # _dashboard_data is attached to the BaseServer instance by
+        # DashboardServer at construction time; ty doesn't see this dynamic
+        # attribute on http.server.BaseServer.
         if self.path == "/api/metrics":
-            body = self.server._dashboard_data.to_json().encode()  # type: ignore[attr-defined]
+            body = self.server._dashboard_data.to_json().encode()  # ty: ignore[unresolved-attribute]
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(body)))
@@ -246,7 +258,7 @@ class _DashboardHandler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(body)
         else:
             body = render_dashboard_html(
-                self.server._dashboard_data  # type: ignore[attr-defined]
+                self.server._dashboard_data  # ty: ignore[unresolved-attribute]
             ).encode()
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
@@ -272,7 +284,7 @@ class DashboardServer:
         self._httpd = http.server.HTTPServer(
             ("127.0.0.1", port), _DashboardHandler
         )
-        self._httpd._dashboard_data = data  # type: ignore[attr-defined]
+        self._httpd._dashboard_data = data  # ty: ignore[unresolved-attribute]  # dynamic attribute used by _DashboardHandler to read data on the server instance
         self._thread: threading.Thread | None = None
 
     @property

--- a/packages/shared/src/shared/helpers.py
+++ b/packages/shared/src/shared/helpers.py
@@ -65,7 +65,7 @@ def is_null_raw_list(value: object) -> bool:
     # pandas arrays/Series: check emptiness before boolean context
     # (avoids "ambiguous truth value of array" ValueError).
     if hasattr(value, "dtype") and hasattr(value, "__len__"):
-        return len(value) == 0
+        return len(value) == 0  # ty: ignore[invalid-argument-type]  # hasattr narrows to a __len__-bearing object; ty's intersection still rejects len()
 
     # Standard Python sequences
     if isinstance(value, (list, tuple)):

--- a/packages/shared/src/shared/otel.py
+++ b/packages/shared/src/shared/otel.py
@@ -60,8 +60,8 @@ _StatusCode: Any = None
 
 if OTEL_ENABLED:
     try:
-        from opentelemetry import trace as _trace_mod
-        from opentelemetry.trace import (
+        from opentelemetry import trace as _trace_mod  # ty: ignore[unresolved-import]  # optional dependency, guarded by OTEL_ENABLED + ImportError catch
+        from opentelemetry.trace import (  # ty: ignore[unresolved-import]  # optional dependency, guarded by OTEL_ENABLED + ImportError catch
             StatusCode as _StatusCode,
         )
 

--- a/packages/shared/src/shared/telemetry.py
+++ b/packages/shared/src/shared/telemetry.py
@@ -24,7 +24,7 @@ _enabled = os.environ.get("PYROSCOPE_ENABLED", "1").lower() not in (
 
 if _enabled:
     try:
-        import pyroscope
+        import pyroscope  # ty: ignore[unresolved-import]  # optional dependency, guarded by _enabled + ImportError catch
 
         pyroscope.configure(
             application_name=os.environ.get("PYROSCOPE_APP_NAME", "nmetl"),


### PR DESCRIPTION
## Summary
- Reduces `uv run ty check packages/pycypher/ packages/shared/` from **92 diagnostics → 0**.
- Four real type-correctness bugs fixed; the remaining changes are targeted `# ty: ignore[code]` suppressions with one-line rationale (replacing wrong-syntax `# type: ignore[code]` mypy pragmas that ty doesn't recognize).
- No new rule categories downgraded.

## Real bug fixes
- **frame_joiner**: `pd.api.types.find_common_type` was removed in pandas 3.x — replaced with `numpy.promote_types` + explicit object-dtype handling.
- **pattern_matcher**: added `Pattern is None` guard in `pattern_match_to_binding_frame` (previously crashed on malformed Match).
- **query_optimizer**: bound `match.where` to a local before passing to `estimate_predicate_selectivity` so the `Optional` narrows.
- **duckdb data_preview**: asserted non-None on `fetchone()` returns from guaranteed-row queries (COUNT, aggregations).

## Type-tightening (no behavior change)
- `binding_frame`, `frame_joiner`: tighten `join_plan` parameter to `JoinPlan | None`.
- `frame_joiner`: tighten predicate utilities from `ASTNode` to `Expression`.
- `cli/security`: tighten `scan_config` parameter to `PipelineConfig`.
- `backend_engine`: `span: Any`, `estimated_rows` cast to int.
- `lazy_eval`: `compute_live_columns` return type → `list[frozenset[str] | None]` to match what's constructed.

## Targeted ignores (with rationale)
- `list/string/conversion/temporal/math scalar_functions`: convert `if nr.all_null` → `if nr.non_null_vals is None` so ty narrows across the early-return.
- `scalar_function_evaluator`, `aggregation_evaluator`, `collection_evaluator`: ignore for concrete-class attribute access via protocol parameter.
- `boolean_evaluator`: ignore for numpy.where with `None` scalar.
- `pandas_backend`: ignore for `merge`'s `how` arg (runtime str narrowed by callers).
- `shared/dashboard`: ignore for dynamic `_dashboard_data` attribute on `HTTPServer`.
- `shared/helpers`: ignore for `len()` on a `hasattr`-narrowed protocol.
- `shared/otel`, `shared/telemetry`, `exceptions/base` (IPython): ignores for optional dependency imports guarded by `ImportError`.
- `nmetl_cli`, `cli/common`: ignore for `DuckDBIOException = None` fallback.
- `pipeline_builder`: ignore for `str → OutputFormat` (pydantic validates at runtime).
- `introspector`: ignore for `pyarrow.compute.min/max` (stub gap).
- `feedback_collector`: ignore for `min(dict, key=dict.get)` overload.
- `variable_manager`, `ast_models/validation`: ignore for `var.name` on `find_all(Variable)` results.
- `grammar_rule_mixins/expressions`, `sinks/neo4j`: equivalent rationale-tagged ignores.

## Test plan
- [x] `uv run ty check packages/pycypher/ packages/shared/` — exits 0
- [x] Full pycypher test suite (excluding large_dataset/load_testing/property_based/benchmarks): **9642 passed, 35 skipped, 4 xfailed**
- [x] `tests/test_evaluator_protocol.py` (verified Protocol surface unchanged) — 8 passed
- [x] `tests/test_lazy_eval*`, `tests/test_pattern_matcher_unit`, `tests/test_query_optimizer`, `tests/test_pipeline_builder`, `tests/test_variable_manager*` — 209 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)