### PR TITLE
Inject evaluator_factory across sub-evaluators/planners; dispatch table for ClauseExecutor

### DIFF
--- a/packages/pycypher/src/pycypher/aggregation_evaluator.py
+++ b/packages/pycypher/src/pycypher/aggregation_evaluator.py
@@ -16,7 +16,10 @@ import pandas as pd
 
 if TYPE_CHECKING:
     from pycypher.ast_models import Arithmetic, CountStar, FunctionInvocation
-    from pycypher.evaluator_protocol import ExpressionEvaluatorProtocol
+    from pycypher.evaluator_protocol import (
+        ExpressionEvaluatorFactory,
+        ExpressionEvaluatorProtocol,
+    )
 from shared.logger import LOGGER
 
 from pycypher.binding_frame import BindingFrame
@@ -203,14 +206,22 @@ class AggregationExpressionEvaluator:
     while providing a focused, testable interface for aggregation operations.
     """
 
-    def __init__(self, frame: BindingFrame) -> None:
+    def __init__(
+        self,
+        frame: BindingFrame,
+        *,
+        evaluator_factory: ExpressionEvaluatorFactory,
+    ) -> None:
         """Initialize aggregation evaluator with binding frame context.
 
         Args:
             frame: BindingFrame providing variable and expression evaluation context
+            evaluator_factory: Factory for constructing a fresh expression
+                evaluator over a derived frame.
 
         """
         self.frame = frame
+        self._evaluator_factory = evaluator_factory
 
     def evaluate_aggregation(
         self,

--- a/packages/pycypher/src/pycypher/aggregation_planner.py
+++ b/packages/pycypher/src/pycypher/aggregation_planner.py
@@ -34,6 +34,7 @@ from pycypher.scalar_functions import ScalarFunctionRegistry
 
 if TYPE_CHECKING:
     from pycypher.binding_frame import BindingFrame
+    from pycypher.evaluator_protocol import ExpressionEvaluatorFactory
 
 #: Dual-purpose functions that are scalar when called with a list literal,
 #: aggregation otherwise.
@@ -56,8 +57,19 @@ _KNOWN_GRAPH_FUNCTIONS: frozenset[str] = frozenset(
 class AggregationPlanner:
     """Detects aggregations in expressions and evaluates projection items.
 
-    Stateless — all state is passed via method parameters.
+    Aggregation-detection state is passed via method parameters; the only
+    constructor-injected dependency is the expression-evaluator factory.
     """
+
+    def __init__(self, *, evaluator_factory: ExpressionEvaluatorFactory) -> None:
+        """Initialise the aggregation planner.
+
+        Args:
+            evaluator_factory: Factory for constructing an expression
+                evaluator over a given (or per-group) frame.
+
+        """
+        self._evaluator_factory = evaluator_factory
 
     def contains_aggregation(self, expression: Any) -> bool:
         """Check recursively whether *expression* contains any aggregate function.
@@ -254,15 +266,13 @@ class AggregationPlanner:
             A plain ``pd.DataFrame``.
 
         """
-        from pycypher.binding_evaluator import BindingExpressionEvaluator
-
         agg_items = [
             i for i in items if self.contains_aggregation(i.expression)
         ]
         non_agg_items = [
             i for i in items if not self.contains_aggregation(i.expression)
         ]
-        evaluator = BindingExpressionEvaluator(frame)
+        evaluator = self._evaluator_factory(frame)
 
         if not agg_items:
             # Simple projection — batch PropertyLookups on the same variable
@@ -337,7 +347,7 @@ class AggregationPlanner:
                 mask = pd.Series(False, index=range(len(frame)))
                 mask.iloc[list(group_idx)] = True
                 group_frame = frame.filter(mask)
-                group_evaluator = BindingExpressionEvaluator(group_frame)
+                group_evaluator = self._evaluator_factory(group_frame)
 
                 # Locate the row in unique_groups that matches this group.
                 if isinstance(group_vals, tuple):

--- a/packages/pycypher/src/pycypher/arithmetic_evaluator.py
+++ b/packages/pycypher/src/pycypher/arithmetic_evaluator.py
@@ -17,7 +17,10 @@ from typing import TYPE_CHECKING, Any, TypeGuard, cast
 import numpy as np
 
 if TYPE_CHECKING:
-    from pycypher.evaluator_protocol import ExpressionEvaluatorProtocol
+    from pycypher.evaluator_protocol import (
+        ExpressionEvaluatorFactory,
+        ExpressionEvaluatorProtocol,
+    )
 import pandas as pd
 from shared.helpers import is_null_value
 from shared.logger import LOGGER
@@ -433,14 +436,22 @@ class ArithmeticExpressionEvaluator:
     while providing a focused, testable interface for arithmetic operations.
     """
 
-    def __init__(self, frame: BindingFrame) -> None:
+    def __init__(
+        self,
+        frame: BindingFrame,
+        *,
+        evaluator_factory: ExpressionEvaluatorFactory,
+    ) -> None:
         """Initialize arithmetic evaluator with binding frame context.
 
         Args:
             frame: BindingFrame providing variable and expression evaluation context
+            evaluator_factory: Factory for constructing a fresh expression
+                evaluator over a derived frame.
 
         """
         self.frame = frame
+        self._evaluator_factory = evaluator_factory
 
     def evaluate_arithmetic(
         self,

--- a/packages/pycypher/src/pycypher/binding_evaluator.py
+++ b/packages/pycypher/src/pycypher/binding_evaluator.py
@@ -389,6 +389,7 @@ class BindingExpressionEvaluator:
 
             self._arithmetic_evaluator = ArithmeticExpressionEvaluator(
                 self.frame,
+                evaluator_factory=type(self),
             )
         return self._arithmetic_evaluator
 
@@ -398,7 +399,10 @@ class BindingExpressionEvaluator:
         if self._boolean_evaluator is None:
             from pycypher.boolean_evaluator import BooleanExpressionEvaluator
 
-            self._boolean_evaluator = BooleanExpressionEvaluator(self.frame)
+            self._boolean_evaluator = BooleanExpressionEvaluator(
+                self.frame,
+                evaluator_factory=type(self),
+            )
         return self._boolean_evaluator
 
     @property
@@ -411,6 +415,7 @@ class BindingExpressionEvaluator:
 
             self._aggregation_evaluator = AggregationExpressionEvaluator(
                 self.frame,
+                evaluator_factory=type(self),
             )
         return self._aggregation_evaluator
 
@@ -424,6 +429,7 @@ class BindingExpressionEvaluator:
 
             self._collection_evaluator = CollectionExpressionEvaluator(
                 self.frame,
+                evaluator_factory=type(self),
             )
         return self._collection_evaluator
 
@@ -433,7 +439,10 @@ class BindingExpressionEvaluator:
         if self._comparison_evaluator is None:
             from pycypher.comparison_evaluator import ComparisonEvaluator
 
-            self._comparison_evaluator = ComparisonEvaluator(self.frame)
+            self._comparison_evaluator = ComparisonEvaluator(
+                self.frame,
+                evaluator_factory=type(self),
+            )
         return self._comparison_evaluator
 
     @property
@@ -446,6 +455,7 @@ class BindingExpressionEvaluator:
 
             self._scalar_function_evaluator = ScalarFunctionEvaluator(
                 self.frame,
+                evaluator_factory=type(self),
             )
         return self._scalar_function_evaluator
 
@@ -457,7 +467,9 @@ class BindingExpressionEvaluator:
                 StringPredicateEvaluator,
             )
 
-            self._string_predicate_evaluator = StringPredicateEvaluator()
+            self._string_predicate_evaluator = StringPredicateEvaluator(
+                evaluator_factory=type(self),
+            )
         return self._string_predicate_evaluator
 
     @property
@@ -466,7 +478,10 @@ class BindingExpressionEvaluator:
         if self._exists_evaluator is None:
             from pycypher.exists_evaluator import ExistsEvaluator
 
-            self._exists_evaluator = ExistsEvaluator(self.frame)
+            self._exists_evaluator = ExistsEvaluator(
+                self.frame,
+                evaluator_factory=type(self),
+            )
         return self._exists_evaluator
 
     # ------------------------------------------------------------------

--- a/packages/pycypher/src/pycypher/boolean_evaluator.py
+++ b/packages/pycypher/src/pycypher/boolean_evaluator.py
@@ -18,7 +18,10 @@ import numpy as np
 
 if TYPE_CHECKING:
     from pycypher.ast_models import Expression
-    from pycypher.evaluator_protocol import ExpressionEvaluatorProtocol
+    from pycypher.evaluator_protocol import (
+        ExpressionEvaluatorFactory,
+        ExpressionEvaluatorProtocol,
+    )
 import pandas as pd
 from shared.logger import LOGGER
 
@@ -131,14 +134,22 @@ class BooleanExpressionEvaluator:
     while providing a focused, testable interface for boolean operations.
     """
 
-    def __init__(self, frame: BindingFrame) -> None:
+    def __init__(
+        self,
+        frame: BindingFrame,
+        *,
+        evaluator_factory: ExpressionEvaluatorFactory,
+    ) -> None:
         """Initialize boolean evaluator with binding frame context.
 
         Args:
             frame: BindingFrame providing variable and expression evaluation context
+            evaluator_factory: Factory for constructing a fresh expression
+                evaluator over a derived frame.
 
         """
         self.frame = frame
+        self._evaluator_factory = evaluator_factory
 
     def evaluate_and(
         self,

--- a/packages/pycypher/src/pycypher/clause_executor.py
+++ b/packages/pycypher/src/pycypher/clause_executor.py
@@ -15,7 +15,7 @@ execution logic from the main orchestration facade.  The
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 import pandas as pd
 from shared.logger import LOGGER
@@ -24,6 +24,7 @@ from shared.metrics import get_rss_mb
 from pycypher.binding_frame import BindingFrame
 
 if TYPE_CHECKING:
+    from pycypher.evaluator_protocol import ExpressionEvaluatorFactory
     from pycypher.frame_joiner import FrameJoiner
     from pycypher.mutation_engine import MutationEngine
     from pycypher.pattern_matcher import PatternMatcher
@@ -56,6 +57,8 @@ class ClauseExecutor:
         frame_joiner: FrameJoiner,
         projection_planner: ProjectionPlanner,
         query_analyzer: QueryAnalyzer,
+        *,
+        evaluator_factory: ExpressionEvaluatorFactory,
     ) -> None:
         self._context = context
         self._pattern_matcher = pattern_matcher
@@ -63,6 +66,35 @@ class ClauseExecutor:
         self._frame_joiner = frame_joiner
         self._projection_planner = projection_planner
         self._query_analyzer = query_analyzer
+        self._evaluator_factory = evaluator_factory
+
+        from pycypher.ast_models import (
+            Call,
+            Create,
+            Delete,
+            Foreach,
+            Match,
+            Merge,
+            Remove,
+            Return,
+            Set,
+            Unwind,
+            With,
+        )
+
+        self._dispatch_table: dict[type, Callable[[Any, Any, int | None], Any]] = {
+            Match: self._dispatch_match,
+            With: self._dispatch_with,
+            Return: self._dispatch_return,
+            Set: self._dispatch_set,
+            Remove: self._dispatch_remove,
+            Delete: self._dispatch_delete,
+            Unwind: self._dispatch_unwind,
+            Create: self._dispatch_create,
+            Call: self._dispatch_call,
+            Merge: self._dispatch_merge,
+            Foreach: self._dispatch_foreach,
+        }
 
     # ------------------------------------------------------------------
     # WHERE filter
@@ -73,6 +105,8 @@ class ClauseExecutor:
         where_expr: Any,
         result_frame: BindingFrame,
         fallback_frame: BindingFrame | None = None,
+        *,
+        evaluator_factory: ExpressionEvaluatorFactory,
     ) -> BindingFrame:
         """Apply a WHERE predicate to *result_frame*, with optional fallback.
 
@@ -84,27 +118,37 @@ class ClauseExecutor:
             where_expr: AST expression node for the WHERE predicate.
             result_frame: The frame to filter.
             fallback_frame: Optional pre-projection frame for variable lookup.
+            evaluator_factory: Factory for constructing an expression
+                evaluator over a given frame.
 
         Returns:
             A new filtered :class:`BindingFrame`.
 
         """
-        from pycypher.binding_evaluator import (
-            BindingExpressionEvaluator as _BEE,
-        )
         from pycypher.binding_frame import BindingFilter
 
         if fallback_frame is None:
-            return BindingFilter(predicate=where_expr).apply(result_frame)
+            return BindingFilter(
+                predicate=where_expr,
+                evaluator_factory=evaluator_factory,
+            ).apply(result_frame)
 
         try:
-            _mask = _BEE(result_frame).evaluate(where_expr).fillna(False)
+            _mask = (
+                evaluator_factory(result_frame)
+                .evaluate(where_expr)
+                .fillna(False)
+            )
             return result_frame.filter(_mask)
         except (ValueError, KeyError):
             LOGGER.debug(
                 "WHERE: evaluation failed on result frame, falling back to pre-projection frame",
             )
-            _pre_mask = _BEE(fallback_frame).evaluate(where_expr).fillna(False)
+            _pre_mask = (
+                evaluator_factory(fallback_frame)
+                .evaluate(where_expr)
+                .fillna(False)
+            )
             return result_frame.filter(_pre_mask)
 
     # ------------------------------------------------------------------
@@ -126,10 +170,8 @@ class ClauseExecutor:
             A new :class:`BindingFrame` with rows expanded from list elements.
 
         """
-        from pycypher.binding_evaluator import BindingExpressionEvaluator
-
         alias: str = clause.alias or "_unwind_col"
-        evaluator = BindingExpressionEvaluator(frame)
+        evaluator = self._evaluator_factory(frame)
         list_series = evaluator.evaluate(clause.expression).reset_index(
             drop=True,
         )
@@ -280,6 +322,125 @@ class ClauseExecutor:
     # Clause dispatch
     # ------------------------------------------------------------------
 
+    def _dispatch_match(
+        self,
+        clause: Any,
+        current_frame: Any,
+        limit_hint: int | None,
+    ) -> Any:
+        return self.handle_match_clause(clause, current_frame, limit_hint)
+
+    def _dispatch_with(
+        self,
+        clause: Any,
+        current_frame: Any,
+        _limit_hint: int | None,
+    ) -> Any:
+        if current_frame is None:
+            current_frame = self._frame_joiner.make_seed_frame()
+        return self._projection_planner.with_to_binding_frame(
+            clause, current_frame,
+        )
+
+    def _dispatch_return(
+        self,
+        clause: Any,
+        current_frame: Any,
+        _limit_hint: int | None,
+    ) -> Any:
+        if current_frame is None:
+            current_frame = self._frame_joiner.make_seed_frame()
+        return self._projection_planner.return_from_frame(
+            clause, current_frame,
+        )
+
+    def _dispatch_set(
+        self,
+        clause: Any,
+        current_frame: Any,
+        _limit_hint: int | None,
+    ) -> Any:
+        self.require_bound_frame(current_frame, "SET")
+        self._mutations.set_properties(clause, current_frame)
+        current_frame._property_cache.clear()
+        return current_frame
+
+    def _dispatch_remove(
+        self,
+        clause: Any,
+        current_frame: Any,
+        _limit_hint: int | None,
+    ) -> Any:
+        self.require_bound_frame(current_frame, "REMOVE")
+        self._mutations.remove_properties(clause, current_frame)
+        current_frame._property_cache.clear()
+        return current_frame
+
+    def _dispatch_delete(
+        self,
+        clause: Any,
+        current_frame: Any,
+        _limit_hint: int | None,
+    ) -> Any:
+        self.require_bound_frame(current_frame, "DELETE")
+        self._mutations.process_delete(clause, current_frame)
+        current_frame._property_cache.clear()
+        return current_frame
+
+    def _dispatch_unwind(
+        self,
+        clause: Any,
+        current_frame: Any,
+        _limit_hint: int | None,
+    ) -> Any:
+        return self.process_unwind_clause(clause, current_frame)
+
+    def _dispatch_create(
+        self,
+        clause: Any,
+        current_frame: Any,
+        _limit_hint: int | None,
+    ) -> Any:
+        return self._mutations.process_create(
+            clause,
+            current_frame,
+            make_seed_frame=self._frame_joiner.make_seed_frame,
+        )
+
+    def _dispatch_call(
+        self,
+        clause: Any,
+        current_frame: Any,
+        _limit_hint: int | None,
+    ) -> Any:
+        return self._mutations.process_call(clause, current_frame)
+
+    def _dispatch_merge(
+        self,
+        clause: Any,
+        current_frame: Any,
+        _limit_hint: int | None,
+    ) -> Any:
+        return self._mutations.process_merge(
+            clause,
+            current_frame,
+            match_to_binding_frame=self._pattern_matcher.match_to_binding_frame,
+            merge_frames_for_match=self._frame_joiner.merge_frames_for_match,
+            make_seed_frame=self._frame_joiner.make_seed_frame,
+        )
+
+    def _dispatch_foreach(
+        self,
+        clause: Any,
+        current_frame: Any,
+        _limit_hint: int | None,
+    ) -> Any:
+        return self._mutations.process_foreach(
+            clause,
+            current_frame,
+            make_seed_frame=self._frame_joiner.make_seed_frame,
+        )
+
     def dispatch_clause(
         self,
         clause: Any,
@@ -292,96 +453,14 @@ class ClauseExecutor:
         OPTIONAL MATCH, or a BindingFrame / ``None`` for all other clauses.
 
         """
-        from pycypher.ast_models import (
-            Call,
-            Create,
-            Delete,
-            Foreach,
-            Match,
-            Merge,
-            Remove,
-            Return,
-            Set,
-            Unwind,
-            With,
-        )
-
-        if isinstance(clause, Match):
-            result = self.handle_match_clause(
-                clause,
-                current_frame,
-                limit_hint,
+        handler = self._dispatch_table.get(type(clause))
+        if handler is None:
+            msg = (
+                f"Clause type '{type(clause).__name__}' is not yet supported "
+                "in the BindingFrame execution path."
             )
-            if isinstance(result, pd.DataFrame):
-                return result
-            return result
-
-        if isinstance(clause, With):
-            if current_frame is None:
-                current_frame = self._frame_joiner.make_seed_frame()
-            return self._projection_planner.with_to_binding_frame(
-                clause, current_frame,
-            )
-
-        if isinstance(clause, Return):
-            if current_frame is None:
-                current_frame = self._frame_joiner.make_seed_frame()
-            return self._projection_planner.return_from_frame(
-                clause, current_frame,
-            )
-
-        if isinstance(clause, Set):
-            self.require_bound_frame(current_frame, "SET")
-            self._mutations.set_properties(clause, current_frame)
-            current_frame._property_cache.clear()
-            return current_frame
-
-        if isinstance(clause, Remove):
-            self.require_bound_frame(current_frame, "REMOVE")
-            self._mutations.remove_properties(clause, current_frame)
-            current_frame._property_cache.clear()
-            return current_frame
-
-        if isinstance(clause, Delete):
-            self.require_bound_frame(current_frame, "DELETE")
-            self._mutations.process_delete(clause, current_frame)
-            current_frame._property_cache.clear()
-            return current_frame
-
-        if isinstance(clause, Unwind):
-            return self.process_unwind_clause(clause, current_frame)
-
-        if isinstance(clause, Create):
-            return self._mutations.process_create(
-                clause,
-                current_frame,
-                make_seed_frame=self._frame_joiner.make_seed_frame,
-            )
-
-        if isinstance(clause, Call):
-            return self._mutations.process_call(clause, current_frame)
-
-        if isinstance(clause, Merge):
-            return self._mutations.process_merge(
-                clause,
-                current_frame,
-                match_to_binding_frame=self._pattern_matcher.match_to_binding_frame,
-                merge_frames_for_match=self._frame_joiner.merge_frames_for_match,
-                make_seed_frame=self._frame_joiner.make_seed_frame,
-            )
-
-        if isinstance(clause, Foreach):
-            return self._mutations.process_foreach(
-                clause,
-                current_frame,
-                make_seed_frame=self._frame_joiner.make_seed_frame,
-            )
-
-        msg = (
-            f"Clause type '{type(clause).__name__}' is not yet supported "
-            "in the BindingFrame execution path."
-        )
-        raise NotImplementedError(msg)
+            raise NotImplementedError(msg)
+        return handler(clause, current_frame, limit_hint)
 
     # ------------------------------------------------------------------
     # Main execution loop

--- a/packages/pycypher/src/pycypher/collection_evaluator.py
+++ b/packages/pycypher/src/pycypher/collection_evaluator.py
@@ -35,7 +35,10 @@ if TYPE_CHECKING:
         Quantifier,
         Reduce,
     )
-    from pycypher.evaluator_protocol import ExpressionEvaluatorProtocol
+    from pycypher.evaluator_protocol import (
+        ExpressionEvaluatorFactory,
+        ExpressionEvaluatorProtocol,
+    )
 from shared.helpers import is_null_raw_list as _is_null_raw_list
 from shared.logger import LOGGER
 
@@ -132,15 +135,23 @@ class CollectionExpressionEvaluator:
 
     """
 
-    def __init__(self, frame: BindingFrame) -> None:
+    def __init__(
+        self,
+        frame: BindingFrame,
+        *,
+        evaluator_factory: ExpressionEvaluatorFactory,
+    ) -> None:
         """Initialize collection evaluator with binding frame context.
 
         Args:
             frame: BindingFrame providing variable bindings and context for
                 collection expression evaluation.
+            evaluator_factory: Factory for constructing a fresh expression
+                evaluator over a derived (exploded/sub) frame.
 
         """
         self.frame = frame
+        self._evaluator_factory = evaluator_factory
 
     def eval_property_lookup(
         self,
@@ -334,7 +345,6 @@ class CollectionExpressionEvaluator:
                 "collection: list_comprehension  rows=%d",
                 len(self.frame),
             )
-        from pycypher.binding_evaluator import BindingExpressionEvaluator
         from pycypher.binding_frame import BindingFrame
 
         var_name: str = lc.variable.name if lc.variable else "_lc_var"
@@ -365,10 +375,8 @@ class CollectionExpressionEvaluator:
             type_registry={},
             context=self.frame.context,
         )
-        flat_evaluator: BindingExpressionEvaluator = (
-            BindingExpressionEvaluator(
-                flat_frame,
-            )
+        flat_evaluator: ExpressionEvaluatorProtocol = self._evaluator_factory(
+            flat_frame,
         )
 
         if lc.where is not None:
@@ -398,10 +406,8 @@ class CollectionExpressionEvaluator:
                 type_registry={},
                 context=self.frame.context,
             )
-            surv_evaluator: BindingExpressionEvaluator = (
-                BindingExpressionEvaluator(
-                    surv_frame,
-                )
+            surv_evaluator: ExpressionEvaluatorProtocol = self._evaluator_factory(
+                surv_frame,
             )
             mapped_values: list[Any] = list(
                 surv_evaluator.evaluate(lc.map_expr),
@@ -547,11 +553,7 @@ class CollectionExpressionEvaluator:
                 )
 
                 # Create evaluator for exploded frame and evaluate WHERE condition ONCE
-                from pycypher.binding_evaluator import (
-                    BindingExpressionEvaluator,
-                )
-
-                exploded_evaluator = BindingExpressionEvaluator(exploded_frame)
+                exploded_evaluator = self._evaluator_factory(exploded_frame)
                 where_results = exploded_evaluator.evaluate(q.where)
 
                 # Phase 4: Group results back by original row and apply quantifier logic
@@ -710,9 +712,7 @@ class CollectionExpressionEvaluator:
             )
 
             # Create evaluator for this step
-            from pycypher.binding_evaluator import BindingExpressionEvaluator
-
-            step_evaluator = BindingExpressionEvaluator(step_frame)
+            step_evaluator = self._evaluator_factory(step_frame)
 
             # Evaluate map_expr ONCE for all active rows
             new_accs = step_evaluator.evaluate(r.map_expr)

--- a/packages/pycypher/src/pycypher/comparison_evaluator.py
+++ b/packages/pycypher/src/pycypher/comparison_evaluator.py
@@ -30,7 +30,10 @@ _DEBUG_ENABLED: bool = LOGGER.isEnabledFor(logging.DEBUG)
 if TYPE_CHECKING:
     from pycypher.ast_models import Expression, WhenClause
     from pycypher.binding_frame import BindingFrame
-    from pycypher.evaluator_protocol import ExpressionEvaluatorProtocol
+    from pycypher.evaluator_protocol import (
+        ExpressionEvaluatorFactory,
+        ExpressionEvaluatorProtocol,
+    )
 
 # ---------------------------------------------------------------------------
 # Operator dispatch tables
@@ -71,15 +74,23 @@ class ComparisonEvaluator:
 
     """
 
-    def __init__(self, frame: BindingFrame) -> None:
+    def __init__(
+        self,
+        frame: BindingFrame,
+        *,
+        evaluator_factory: ExpressionEvaluatorFactory,
+    ) -> None:
         """Initialise with a binding frame.
 
         Args:
             frame: The :class:`BindingFrame` against which expressions are
                 evaluated.
+            evaluator_factory: Factory for constructing a fresh expression
+                evaluator over a derived frame.
 
         """
         self.frame = frame
+        self._evaluator_factory = evaluator_factory
 
     # ------------------------------------------------------------------
     # Comparisons

--- a/packages/pycypher/src/pycypher/exists_evaluator.py
+++ b/packages/pycypher/src/pycypher/exists_evaluator.py
@@ -31,7 +31,10 @@ from pycypher.relational_models import (
 if TYPE_CHECKING:
     from pycypher.ast_models import PatternComprehension
     from pycypher.binding_frame import BindingFrame
-    from pycypher.evaluator_protocol import ExpressionEvaluatorProtocol
+    from pycypher.evaluator_protocol import (
+        ExpressionEvaluatorFactory,
+        ExpressionEvaluatorProtocol,
+    )
 
 _DEBUG_ENABLED: bool = LOGGER.isEnabledFor(logging.DEBUG)
 
@@ -51,15 +54,23 @@ class ExistsEvaluator:
 
     """
 
-    def __init__(self, frame: BindingFrame) -> None:
+    def __init__(
+        self,
+        frame: BindingFrame,
+        *,
+        evaluator_factory: ExpressionEvaluatorFactory,
+    ) -> None:
         """Initialise with the current binding frame.
 
         Args:
             frame: The :class:`BindingFrame` to evaluate EXISTS predicates
                 and pattern comprehensions against.
+            evaluator_factory: Factory for constructing a fresh expression
+                evaluator over a derived (sub) frame.
 
         """
         self.frame = frame
+        self._evaluator_factory = evaluator_factory
 
     # ------------------------------------------------------------------
     # EXISTS predicate
@@ -355,7 +366,6 @@ class ExistsEvaluator:
         orig_index = self.frame.bindings.index
 
         # Vectorised path: one pandas merge replaces O(n_rows × m_matches).
-        from pycypher.binding_evaluator import BindingExpressionEvaluator
         from pycypher.binding_frame import BindingFrame
 
         anchor_frame = pd.DataFrame(
@@ -390,7 +400,7 @@ class ExistsEvaluator:
             type_registry=sub_type_reg,
             context=self.frame.context,
         )
-        pairs_eval = BindingExpressionEvaluator(sub_frame)
+        pairs_eval = self._evaluator_factory(sub_frame)
 
         if pc.where is not None:
             keep_raw = pairs_eval.evaluate(pc.where)
@@ -404,7 +414,7 @@ class ExistsEvaluator:
                 type_registry=sub_type_reg,
                 context=self.frame.context,
             )
-            pairs_eval = BindingExpressionEvaluator(sub_frame)
+            pairs_eval = self._evaluator_factory(sub_frame)
 
         if pc.map_expr is not None:
             mapped = pairs_eval.evaluate(pc.map_expr)

--- a/packages/pycypher/src/pycypher/mutation_engine.py
+++ b/packages/pycypher/src/pycypher/mutation_engine.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     )
     from pycypher.backend_engine import BackendEngine
     from pycypher.binding_frame import BindingFrame
+    from pycypher.evaluator_protocol import ExpressionEvaluatorFactory
     from pycypher.relational_models import Context
 
 
@@ -87,15 +88,23 @@ class MutationEngine:
 
     """
 
-    def __init__(self, context: Context) -> None:
+    def __init__(
+        self,
+        context: Context,
+        *,
+        evaluator_factory: ExpressionEvaluatorFactory,
+    ) -> None:
         """Initialize mutation engine.
 
         Args:
             context: The execution context holding entity and relationship
                 mappings. Mutations are applied through the shadow-write layer.
+            evaluator_factory: Factory for constructing an expression
+                evaluator over a given frame.
 
         """
         self.context: Context = context
+        self._evaluator_factory = evaluator_factory
 
     @property
     def _backend(self) -> BackendEngine | None:
@@ -126,13 +135,12 @@ class MutationEngine:
         """
         t0 = time.perf_counter()
         from pycypher.ast_models import MapLiteral, SetItem, SetPropertyItem
-        from pycypher.binding_evaluator import BindingExpressionEvaluator
 
         n_items = len(set_clause.items)
         n_rows = len(frame)
         LOGGER.debug("mutation SET: %d items, %d rows", n_items, n_rows)
 
-        evaluator = BindingExpressionEvaluator(frame)
+        evaluator = self._evaluator_factory(frame)
 
         for item in set_clause.items:
             if not isinstance(item, (SetPropertyItem, SetItem)):
@@ -477,7 +485,6 @@ class MutationEngine:
             RelationshipDirection,
             RelationshipPattern,
         )
-        from pycypher.binding_evaluator import BindingExpressionEvaluator
         from pycypher.binding_frame import BindingFrame
 
         if clause.pattern is None:
@@ -495,7 +502,7 @@ class MutationEngine:
         eval_frame = (
             make_seed_frame() if current_frame is None else current_frame
         )
-        evaluator = BindingExpressionEvaluator(eval_frame)
+        evaluator = self._evaluator_factory(eval_frame)
 
         new_vars: dict[str, pd.Series] = {}
         new_type_reg: dict[str, str] = {}
@@ -623,7 +630,6 @@ class MutationEngine:
         """
         t0 = time.perf_counter()
         from pycypher.ast_models import Variable
-        from pycypher.binding_evaluator import BindingExpressionEvaluator
         from pycypher.dataframe_utils import (
             source_to_pandas as _source_to_pandas,
         )
@@ -636,7 +642,7 @@ class MutationEngine:
             len(frame),
         )
 
-        evaluator = BindingExpressionEvaluator(frame)
+        evaluator = self._evaluator_factory(frame)
 
         for expr in clause.expressions:
             id_series = evaluator.evaluate(expr)
@@ -867,7 +873,6 @@ class MutationEngine:
         """
         t0 = time.perf_counter()
         from pycypher.ast_models import Create, Delete, Merge, Remove, Set
-        from pycypher.binding_evaluator import BindingExpressionEvaluator
         from pycypher.binding_frame import BindingFrame
 
         n_clauses = len(clause.clauses) if clause.clauses else 0
@@ -943,7 +948,7 @@ class MutationEngine:
 
         if current_frame is None:
             synthetic_frame = make_seed_frame()
-            evaluator = BindingExpressionEvaluator(frame=synthetic_frame)
+            evaluator = self._evaluator_factory(frame=synthetic_frame)
             list_series = evaluator.evaluate(clause.list_expression)
             raw_list = list_series.iloc[0] if len(list_series) > 0 else []
             if raw_list is None:
@@ -966,7 +971,7 @@ class MutationEngine:
                     element_value=element,
                 )
         else:
-            evaluator = BindingExpressionEvaluator(frame=current_frame)
+            evaluator = self._evaluator_factory(frame=current_frame)
             list_series = evaluator.evaluate(clause.list_expression)
 
             # Pre-compute rows as dicts and list values to avoid
@@ -1069,7 +1074,6 @@ class MutationEngine:
             YIELDed columns.
 
         """
-        from pycypher.binding_evaluator import BindingExpressionEvaluator
         from pycypher.binding_frame import BindingFrame
         from pycypher.relational_models import PROCEDURE_REGISTRY
 
@@ -1086,7 +1090,7 @@ class MutationEngine:
 
         args: list[Any] = []
         if clause.arguments and current_frame is not None:
-            evaluator = BindingExpressionEvaluator(current_frame)
+            evaluator = self._evaluator_factory(current_frame)
             for arg_expr in clause.arguments:
                 series = evaluator.evaluate(arg_expr)
                 args.append(series.iloc[0] if len(series) > 0 else None)

--- a/packages/pycypher/src/pycypher/pattern_matcher.py
+++ b/packages/pycypher/src/pycypher/pattern_matcher.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from pycypher.ast_models import Match
+    from pycypher.evaluator_protocol import ExpressionEvaluatorFactory
     from pycypher.relational_models import Context
 
 #: Synthetic variable name prefix for anonymous nodes.
@@ -122,6 +123,8 @@ class PatternMatcher:
         coerce_join_fn: Callable[..., BindingFrame],
         apply_where_fn: Callable[..., BindingFrame],
         multi_way_join_fn: Callable[..., BindingFrame] | None = None,
+        *,
+        evaluator_factory: ExpressionEvaluatorFactory,
     ) -> None:
         """Initialize pattern matcher.
 
@@ -134,6 +137,9 @@ class PatternMatcher:
                 for applying a WHERE predicate to a frame.
             multi_way_join_fn: Optional callable ``(frames) -> BindingFrame``
                 for n-way joins using LeapfrogTriejoin when applicable.
+            evaluator_factory: Factory for constructing an expression
+                evaluator, threaded into inline-property ``BindingFilter``
+                construction.
 
         """
         self.context = context
@@ -141,6 +147,7 @@ class PatternMatcher:
         self._coerce_join = coerce_join_fn
         self._apply_where_filter = apply_where_fn
         self._multi_way_join = multi_way_join_fn
+        self._evaluator_factory = evaluator_factory
 
     def node_pattern_to_binding_frame(
         self,
@@ -255,7 +262,10 @@ class PatternMatcher:
                 ),
                 right=prop_val,
             )
-            frame = BindingFilter(predicate=predicate).apply(frame)
+            frame = BindingFilter(
+                predicate=predicate,
+                evaluator_factory=self._evaluator_factory,
+            ).apply(frame)
         # For labelled nodes with pushdown, the pushed predicates have already
         # filtered at scan time — no need to re-apply them.
 
@@ -639,7 +649,10 @@ class PatternMatcher:
                         ),
                         right=prop_val,
                     )
-                    hop_f = BindingFilter(predicate=predicate).apply(
+                    hop_f = BindingFilter(
+                        predicate=predicate,
+                        evaluator_factory=self._evaluator_factory,
+                    ).apply(
                         hop_f,
                     )
 

--- a/packages/pycypher/src/pycypher/projection_planner.py
+++ b/packages/pycypher/src/pycypher/projection_planner.py
@@ -26,6 +26,7 @@ from shared.logger import LOGGER
 if TYPE_CHECKING:
     from pycypher.aggregation_planner import AggregationPlanner
     from pycypher.binding_frame import BindingFrame
+    from pycypher.evaluator_protocol import ExpressionEvaluatorFactory
     from pycypher.expression_renderer import ExpressionRenderer
 
 
@@ -50,6 +51,8 @@ class ProjectionPlanner:
         agg_planner: AggregationPlanner,
         renderer: ExpressionRenderer,
         where_fn: Callable[..., BindingFrame],
+        *,
+        evaluator_factory: ExpressionEvaluatorFactory,
     ) -> None:
         """Initialise the projection planner.
 
@@ -60,11 +63,14 @@ class ProjectionPlanner:
                 explicit ``AS`` alias is provided.
             where_fn: Callback to apply a WHERE filter to a
                 :class:`BindingFrame`.
+            evaluator_factory: Factory for constructing an expression
+                evaluator over a given frame.
 
         """
         self._agg_planner = agg_planner
         self._renderer = renderer
         self._where_fn = where_fn
+        self._evaluator_factory = evaluator_factory
 
     def infer_alias(self, expression: Any) -> str | None:
         """Infer a display alias from an expression when none is given.
@@ -138,7 +144,6 @@ class ProjectionPlanner:
             A new ``pd.DataFrame`` with modifiers applied.
 
         """
-        from pycypher.binding_evaluator import BindingExpressionEvaluator
         from pycypher.binding_frame import BindingFrame
 
         # ── DISTINCT ─────────────────────────────────────────────────────────
@@ -172,7 +177,7 @@ class ProjectionPlanner:
             for idx, order_item in enumerate(order_by):
                 sort_col = f"__sort_{idx}__"
                 try:
-                    evaluator = BindingExpressionEvaluator(post_frame)
+                    evaluator = self._evaluator_factory(post_frame)
                     sort_series = evaluator.evaluate(
                         order_item.expression,
                     ).reset_index(drop=True)
@@ -187,7 +192,7 @@ class ProjectionPlanner:
                         _sort_exc,
                         idx,
                     )
-                    evaluator = BindingExpressionEvaluator(frame)
+                    evaluator = self._evaluator_factory(frame)
                     sort_series = evaluator.evaluate(
                         order_item.expression,
                     ).reset_index(drop=True)
@@ -239,7 +244,7 @@ class ProjectionPlanner:
         skip_val: Any = getattr(clause, "skip", None)
         if skip_val is not None:
             if not isinstance(skip_val, int):
-                evaluator = BindingExpressionEvaluator(frame)
+                evaluator = self._evaluator_factory(frame)
                 skip_val = int(evaluator.evaluate(skip_val).iloc[0])
             df = df.iloc[int(skip_val) :].reset_index(drop=True)
 
@@ -248,7 +253,7 @@ class ProjectionPlanner:
         limit_val: Any = getattr(clause, "limit", None)
         if limit_val is not None:
             if not isinstance(limit_val, int):
-                evaluator = BindingExpressionEvaluator(frame)
+                evaluator = self._evaluator_factory(frame)
                 limit_val = int(evaluator.evaluate(limit_val).iloc[0])
             df = df.iloc[: int(limit_val)].reset_index(drop=True)
 

--- a/packages/pycypher/src/pycypher/scalar_function_evaluator.py
+++ b/packages/pycypher/src/pycypher/scalar_function_evaluator.py
@@ -18,7 +18,10 @@ from typing import TYPE_CHECKING, Any
 import pandas as pd
 
 if TYPE_CHECKING:
-    from pycypher.evaluator_protocol import ExpressionEvaluatorProtocol
+    from pycypher.evaluator_protocol import (
+        ExpressionEvaluatorFactory,
+        ExpressionEvaluatorProtocol,
+    )
 from shared.logger import LOGGER
 
 from pycypher.aggregation_evaluator import KNOWN_AGGREGATIONS
@@ -60,15 +63,23 @@ class ScalarFunctionEvaluator:
       used in scalar expression contexts.
     """
 
-    def __init__(self, frame: BindingFrame) -> None:
+    def __init__(
+        self,
+        frame: BindingFrame,
+        *,
+        evaluator_factory: ExpressionEvaluatorFactory,
+    ) -> None:
         """Initialize scalar function evaluator with binding frame context.
 
         Args:
             frame: The BindingFrame containing variable bindings, type registry,
                 and context for function evaluation.
+            evaluator_factory: Factory for constructing a fresh expression
+                evaluator over a derived frame.
 
         """
         self.frame = frame
+        self._evaluator_factory = evaluator_factory
 
     def evaluate_scalar_function(
         self,

--- a/packages/pycypher/src/pycypher/scan_operators.py
+++ b/packages/pycypher/src/pycypher/scan_operators.py
@@ -36,6 +36,7 @@ from pycypher.dataframe_utils import source_to_pandas as _source_to_pandas
 if TYPE_CHECKING:
     from pycypher.ast_models import Expression
     from pycypher.binding_frame import BindingFrame
+    from pycypher.evaluator_protocol import ExpressionEvaluatorFactory
 
 # ---------------------------------------------------------------------------
 # Performance: module-level debug check avoids per-call overhead
@@ -482,6 +483,7 @@ class BindingFilter:
     """
 
     predicate: Expression
+    evaluator_factory: ExpressionEvaluatorFactory
 
     def apply(self, frame: BindingFrame) -> BindingFrame:
         """Return a new BindingFrame containing only rows where *predicate* is True.
@@ -496,10 +498,7 @@ class BindingFilter:
         if _DEBUG_ENABLED:
             _t0 = time.perf_counter()
             _rows_before = len(frame)
-        # Import here to avoid circular dependency at module load time
-        from pycypher.binding_evaluator import BindingExpressionEvaluator
-
-        evaluator = BindingExpressionEvaluator(frame)
+        evaluator = self.evaluator_factory(frame)
         mask: FrameSeries = evaluator.evaluate(self.predicate).fillna(False).astype(bool)
         result = frame.filter(mask)
         if _DEBUG_ENABLED:

--- a/packages/pycypher/src/pycypher/star.py
+++ b/packages/pycypher/src/pycypher/star.py
@@ -178,8 +178,24 @@ class Star:
         # Track variable-to-type mappings during pattern processing
         self.variable_type_registry: dict[Variable, str] = {}
 
+        # Single production expression-evaluator factory, injected into every
+        # component that needs to construct an evaluator over a frame — see
+        # IMPLEMENTATION_PLAN.md Phase 8 (evaluator-factory injection).
+        from functools import partial
+
+        from pycypher.binding_evaluator import BindingExpressionEvaluator
+
+        self._evaluator_factory = BindingExpressionEvaluator
+        _where_fn = partial(
+            ClauseExecutor.apply_where_filter,
+            evaluator_factory=self._evaluator_factory,
+        )
+
         # Delegate all mutation operations to the focused MutationEngine.
-        self._mutations: MutationEngine = MutationEngine(context=context)
+        self._mutations: MutationEngine = MutationEngine(
+            context=context,
+            evaluator_factory=self._evaluator_factory,
+        )
 
         # Delegate BFS path expansion to the focused PathExpander.
         self._path_expander: PathExpander = PathExpander(context=context)
@@ -192,7 +208,7 @@ class Star:
             match_fn=lambda clause, **kw: (
                 self._pattern_matcher.match_to_binding_frame(clause, **kw)
             ),
-            where_fn=ClauseExecutor.apply_where_filter,
+            where_fn=_where_fn,
         )
 
         # Delegate pattern matching to the focused PatternMatcher.
@@ -200,8 +216,9 @@ class Star:
             context=context,
             path_expander=self._path_expander,
             coerce_join_fn=self._frame_joiner.coerce_join,
-            apply_where_fn=ClauseExecutor.apply_where_filter,
+            apply_where_fn=_where_fn,
             multi_way_join_fn=self._frame_joiner.multi_way_join,
+            evaluator_factory=self._evaluator_factory,
         )
 
         # Delegate expression rendering.
@@ -210,7 +227,9 @@ class Star:
         # Delegate aggregation detection and planning.
         from pycypher.aggregation_planner import AggregationPlanner
 
-        self._agg_planner: AggregationPlanner = AggregationPlanner()
+        self._agg_planner: AggregationPlanner = AggregationPlanner(
+            evaluator_factory=self._evaluator_factory,
+        )
 
         # Delegate RETURN/WITH clause evaluation and projection modifiers.
         from pycypher.projection_planner import ProjectionPlanner
@@ -218,7 +237,8 @@ class Star:
         self._projection_planner: ProjectionPlanner = ProjectionPlanner(
             agg_planner=self._agg_planner,
             renderer=self._renderer,
-            where_fn=ClauseExecutor.apply_where_filter,
+            where_fn=_where_fn,
+            evaluator_factory=self._evaluator_factory,
         )
 
         # Cardinality feedback store.
@@ -242,6 +262,7 @@ class Star:
             frame_joiner=self._frame_joiner,
             projection_planner=self._projection_planner,
             query_analyzer=self._query_analyzer,
+            evaluator_factory=self._evaluator_factory,
         )
 
         # Query explainer — EXPLAIN text plans.
@@ -393,6 +414,7 @@ class Star:
             where_expr,
             result_frame,
             fallback_frame,
+            evaluator_factory=self._evaluator_factory,
         )
 
     def _apply_projection_modifiers(

--- a/packages/pycypher/src/pycypher/string_predicate_evaluator.py
+++ b/packages/pycypher/src/pycypher/string_predicate_evaluator.py
@@ -24,7 +24,10 @@ from pycypher.exceptions import UnsupportedOperatorError, WrongCypherTypeError
 
 if TYPE_CHECKING:
     from pycypher.ast_models import Expression
-    from pycypher.evaluator_protocol import ExpressionEvaluatorProtocol
+    from pycypher.evaluator_protocol import (
+        ExpressionEvaluatorFactory,
+        ExpressionEvaluatorProtocol,
+    )
 
 _DEBUG_ENABLED: bool = LOGGER.isEnabledFor(logging.DEBUG)
 
@@ -125,6 +128,17 @@ class StringPredicateEvaluator:
     * ``"NOT IN"`` — inverse membership test (three-valued logic)
 
     """
+
+    def __init__(self, *, evaluator_factory: ExpressionEvaluatorFactory) -> None:
+        """Initialise the (stateless) string predicate evaluator.
+
+        Args:
+            evaluator_factory: Factory for constructing a fresh expression
+                evaluator over a derived frame. Unused today — accepted for
+                interface uniformity with the other sub-evaluators.
+
+        """
+        self._evaluator_factory = evaluator_factory
 
     def evaluate_string_predicate(
         self,

--- a/tests/test_aggregation_evaluator.py
+++ b/tests/test_aggregation_evaluator.py
@@ -30,6 +30,7 @@ from pycypher.ast_models import (
     FunctionInvocation,
     IntegerLiteral,
 )
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.binding_frame import BindingFrame
 from pycypher.relational_models import (
     ID_COLUMN,
@@ -308,11 +309,11 @@ class TestAggregationExpressionEvaluator:
         test_frame: BindingFrame,
     ) -> AggregationExpressionEvaluator:
         """Create AggregationExpressionEvaluator instance."""
-        return AggregationExpressionEvaluator(test_frame)
+        return AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
 
     def test_evaluator_initialization(self, test_frame: BindingFrame) -> None:
         """Test evaluator initializes correctly."""
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         assert evaluator.frame is test_frame
 
 
@@ -353,7 +354,7 @@ class TestCountStarEvaluation:
         """Test COUNT(*) returns frame length."""
         count_star = CountStar()
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         result = evaluator.evaluate_aggregation(count_star, None)
         assert result == 4  # Length of test frame
 
@@ -411,7 +412,7 @@ class TestFunctionInvocationEvaluation:
                     return pd.Series([50000, 60000, None, 80000, 90000])
                 return pd.Series([0, 0, 0, 0, 0])
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         mock_evaluator = MockExpressionEvaluator()
         result = evaluator.evaluate_aggregation(sum_function, mock_evaluator)
 
@@ -432,7 +433,7 @@ class TestFunctionInvocationEvaluation:
                     return pd.Series([50000, 60000, None, 80000, 90000])
                 return pd.Series([0, 0, 0, 0, 0])
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         mock_evaluator = MockExpressionEvaluator()
         result = evaluator.evaluate_aggregation(count_function, mock_evaluator)
 
@@ -443,7 +444,7 @@ class TestFunctionInvocationEvaluation:
         """Test COUNT() without expression - equivalent to COUNT(*)."""
         count_function = FunctionInvocation(name="count", arguments=None)
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         result = evaluator.evaluate_aggregation(count_function, None)
 
         # COUNT() should return frame length
@@ -464,7 +465,7 @@ class TestFunctionInvocationEvaluation:
             def evaluate(expr):
                 return pd.Series([1, 2, 3, 4, 5])
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         mock_evaluator = MockExpressionEvaluator()
 
         # Import the expected exception
@@ -532,7 +533,7 @@ class TestDistinctAggregation:
                     )  # Duplicates: should sum to 1+2+3=6
                 return pd.Series([0, 0, 0, 0, 0])
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         mock_evaluator = MockExpressionEvaluator()
         result = evaluator.evaluate_aggregation(
             sum_distinct_function,
@@ -597,7 +598,7 @@ class TestPercentileAggregations:
                     return pd.Series([0.5])
                 return pd.Series([0])
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         mock_evaluator = MockExpressionEvaluator()
         result = evaluator.evaluate_aggregation(
             percentile_cont_function,
@@ -626,7 +627,7 @@ class TestPercentileAggregations:
                     return pd.Series([0.5])
                 return pd.Series([0])
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         mock_evaluator = MockExpressionEvaluator()
         result = evaluator.evaluate_aggregation(
             percentile_disc_function,
@@ -654,7 +655,7 @@ class TestPercentileAggregations:
             def evaluate(expr):
                 return pd.Series([10, 20, 30, 40, 50])
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         mock_evaluator = MockExpressionEvaluator()
 
         from pycypher.exceptions import FunctionArgumentError
@@ -708,7 +709,7 @@ class TestGroupedAggregation:
             },
         )
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         result = evaluator.evaluate_aggregation_grouped(
             count_star,
             group_df,
@@ -743,7 +744,7 @@ class TestGroupedAggregation:
             },
         )
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         mock_evaluator = MockExpressionEvaluator()
         result = evaluator.evaluate_aggregation_grouped(
             sum_function,
@@ -782,7 +783,7 @@ class TestGroupedAggregation:
             },
         )
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         mock_evaluator = MockExpressionEvaluator()
         result = evaluator.evaluate_aggregation_grouped(
             unsupported_function,
@@ -845,7 +846,7 @@ class TestArithmeticInAggregation:
                     return expr.value
                 return 0
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         mock_evaluator = MockExpressionEvaluator()
         result = evaluator.evaluate_aggregation(
             arithmetic_expr,
@@ -872,7 +873,7 @@ class TestArithmeticInAggregation:
             def _eval_as_scalar(self, expr):
                 return expr.value
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         mock_evaluator = MockExpressionEvaluator()
         result = evaluator.evaluate_aggregation(division_expr, mock_evaluator)
 
@@ -896,7 +897,7 @@ class TestArithmeticInAggregation:
             def _eval_as_scalar(self, expr):
                 return expr.value
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         mock_evaluator = MockExpressionEvaluator()
 
         with pytest.raises(TypeError, match="Operator '@' incompatible"):
@@ -930,7 +931,7 @@ class TestErrorHandling:
         class InvalidExpression:
             pass
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
 
         with pytest.raises(
             ValueError,
@@ -945,7 +946,7 @@ class TestErrorHandling:
         """Test aggregation without required argument raises ValueError."""
         sum_function = FunctionInvocation(name="sum", arguments=None)
 
-        evaluator = AggregationExpressionEvaluator(test_frame)
+        evaluator = AggregationExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
 
         from pycypher.exceptions import FunctionArgumentError
 

--- a/tests/test_aggregation_planner.py
+++ b/tests/test_aggregation_planner.py
@@ -9,9 +9,10 @@ Tests the two public methods of ``AggregationPlanner``:
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pandas as pd
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.aggregation_planner import AggregationPlanner
 from pycypher.ast_models import (
     Comparison,
@@ -58,7 +59,7 @@ class TestContainsAggregationBaseCases:
     """Test contains_aggregation for atomic / leaf expressions."""
 
     def setup_method(self) -> None:
-        self.planner = AggregationPlanner()
+        self.planner = AggregationPlanner(evaluator_factory=BindingExpressionEvaluator)
 
     def test_none_expression(self) -> None:
         assert self.planner.contains_aggregation(None) is False
@@ -89,7 +90,7 @@ class TestContainsAggregationFunctions:
     """Test contains_aggregation for FunctionInvocation nodes."""
 
     def setup_method(self) -> None:
-        self.planner = AggregationPlanner()
+        self.planner = AggregationPlanner(evaluator_factory=BindingExpressionEvaluator)
 
     def test_known_aggregation_count(self) -> None:
         assert (
@@ -182,7 +183,7 @@ class TestContainsAggregationDualPurpose:
     """Test min/max disambiguation: list-literal → scalar, else agg."""
 
     def setup_method(self) -> None:
-        self.planner = AggregationPlanner()
+        self.planner = AggregationPlanner(evaluator_factory=BindingExpressionEvaluator)
 
     def test_min_with_property_is_aggregation(self) -> None:
         expr = _func("min", [_prop("p", "age")])
@@ -232,7 +233,7 @@ class TestContainsAggregationComposite:
     """Test aggregation detection through compound AST structures."""
 
     def setup_method(self) -> None:
-        self.planner = AggregationPlanner()
+        self.planner = AggregationPlanner(evaluator_factory=BindingExpressionEvaluator)
 
     def test_binary_expression_left_agg(self) -> None:
         expr = Comparison(
@@ -301,7 +302,7 @@ class TestAggregateItemsSimpleProjection:
     """When no items contain aggregation, delegate to _simple_projection."""
 
     def setup_method(self) -> None:
-        self.planner = AggregationPlanner()
+        self.planner = AggregationPlanner(evaluator_factory=BindingExpressionEvaluator)
 
     def test_simple_projection_variables(self) -> None:
         """Simple projection of variables returns DataFrame with correct aliases."""
@@ -320,11 +321,8 @@ class TestAggregateItemsSimpleProjection:
 
         items = [_return_item(Variable(name="x"), "x")]
 
-        with patch(
-            "pycypher.binding_evaluator.BindingExpressionEvaluator",
-            return_value=evaluator_instance,
-        ):
-            result = self.planner.aggregate_items(items, frame)
+        self.planner._evaluator_factory = MagicMock(return_value=evaluator_instance)
+        result = self.planner.aggregate_items(items, frame)
 
         assert list(result.columns) == ["x"]
         assert list(result["x"]) == [1, 2, 3]
@@ -339,7 +337,7 @@ class TestAggregateItemsFullTable:
     """All items are aggregations → single aggregated row."""
 
     def setup_method(self) -> None:
-        self.planner = AggregationPlanner()
+        self.planner = AggregationPlanner(evaluator_factory=BindingExpressionEvaluator)
 
     def test_full_table_count_star(self) -> None:
         frame = MagicMock()
@@ -350,11 +348,8 @@ class TestAggregateItemsFullTable:
 
         items = [_return_item(CountStar(), "cnt")]
 
-        with patch(
-            "pycypher.binding_evaluator.BindingExpressionEvaluator",
-            return_value=evaluator_instance,
-        ):
-            result = self.planner.aggregate_items(items, frame)
+        self.planner._evaluator_factory = MagicMock(return_value=evaluator_instance)
+        result = self.planner.aggregate_items(items, frame)
 
         assert list(result.columns) == ["cnt"]
         assert len(result) == 1
@@ -381,11 +376,8 @@ class TestAggregateItemsFullTable:
             _return_item(_func("avg", [_prop("p", "age")]), "avg_age"),
         ]
 
-        with patch(
-            "pycypher.binding_evaluator.BindingExpressionEvaluator",
-            return_value=evaluator_instance,
-        ):
-            result = self.planner.aggregate_items(items, frame)
+        self.planner._evaluator_factory = MagicMock(return_value=evaluator_instance)
+        result = self.planner.aggregate_items(items, frame)
 
         assert list(result.columns) == ["cnt", "avg_age"]
         assert len(result) == 1
@@ -400,7 +392,7 @@ class TestAggregateItemsGrouped:
     """Mixed agg + non-agg items → grouped aggregation."""
 
     def setup_method(self) -> None:
-        self.planner = AggregationPlanner()
+        self.planner = AggregationPlanner(evaluator_factory=BindingExpressionEvaluator)
 
     def test_grouped_aggregation_basic(self) -> None:
         """Group by a single key with a count aggregation."""
@@ -424,11 +416,8 @@ class TestAggregateItemsGrouped:
             _return_item(CountStar(), "cnt"),
         ]
 
-        with patch(
-            "pycypher.binding_evaluator.BindingExpressionEvaluator",
-            return_value=evaluator_instance,
-        ):
-            result = self.planner.aggregate_items(items, frame)
+        self.planner._evaluator_factory = MagicMock(return_value=evaluator_instance)
+        result = self.planner.aggregate_items(items, frame)
 
         assert "dept" in result.columns
         assert "cnt" in result.columns
@@ -461,7 +450,7 @@ class TestAggregateItemsGrouped:
             _return_item(CountStar(), "cnt"),
         ]
 
-        # Patch BindingExpressionEvaluator to return different evaluators
+        # Return different evaluators depending on call order.
         call_count = 0
 
         def evaluator_factory(f: Any) -> Any:
@@ -471,11 +460,8 @@ class TestAggregateItemsGrouped:
                 return evaluator_instance
             return sub_evaluator
 
-        with patch(
-            "pycypher.binding_evaluator.BindingExpressionEvaluator",
-            side_effect=evaluator_factory,
-        ):
-            result = self.planner.aggregate_items(items, frame)
+        self.planner._evaluator_factory = evaluator_factory
+        result = self.planner.aggregate_items(items, frame)
 
         assert "grp" in result.columns
         assert "cnt" in result.columns
@@ -490,7 +476,7 @@ class TestContainsAggregationFuncArgs:
     """Test argument normalisation paths in _contains_aggregation_in_func_args."""
 
     def setup_method(self) -> None:
-        self.planner = AggregationPlanner()
+        self.planner = AggregationPlanner(evaluator_factory=BindingExpressionEvaluator)
 
     def test_dict_arguments_with_aggregation(self) -> None:
         """FunctionInvocation.arguments as dict with 'arguments' key."""

--- a/tests/test_arithmetic_evaluator.py
+++ b/tests/test_arithmetic_evaluator.py
@@ -20,6 +20,7 @@ from pycypher.arithmetic_evaluator import (
     _first_non_null_val,
     _is_temporal_val,
 )
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.binding_frame import BindingFrame
 from pycypher.relational_models import (
     ID_COLUMN,
@@ -208,11 +209,11 @@ class TestArithmeticExpressionEvaluator:
         test_frame: BindingFrame,
     ) -> ArithmeticExpressionEvaluator:
         """Create ArithmeticExpressionEvaluator instance."""
-        return ArithmeticExpressionEvaluator(test_frame)
+        return ArithmeticExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
 
     def test_evaluator_initialization(self, test_frame: BindingFrame) -> None:
         """Test evaluator initializes correctly."""
-        evaluator = ArithmeticExpressionEvaluator(test_frame)
+        evaluator = ArithmeticExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         assert evaluator.frame is test_frame
 
     def test_evaluate_arithmetic_addition(

--- a/tests/test_binding_frame.py
+++ b/tests/test_binding_frame.py
@@ -690,7 +690,7 @@ class TestBindingFilter:
             ),
             right=StringLiteral(value="Alice"),
         )
-        filtered = BindingFilter(predicate=predicate).apply(bf)
+        filtered = BindingFilter(predicate=predicate, evaluator_factory=BindingExpressionEvaluator).apply(bf)
         assert len(filtered) == 1
         names = filtered.get_property("p", "name")
         assert list(names) == ["Alice"]
@@ -710,7 +710,7 @@ class TestBindingFilter:
             left=PropertyLookup(expression=Variable(name="p"), property="age"),
             right=IntegerLiteral(value=25),
         )
-        filtered = BindingFilter(predicate=predicate).apply(bf)
+        filtered = BindingFilter(predicate=predicate, evaluator_factory=BindingExpressionEvaluator).apply(bf)
         assert len(filtered) == 2
         names = set(filtered.get_property("p", "name"))
         assert names == {"Alice", "Carol"}
@@ -746,7 +746,7 @@ class TestBindingFilter:
                 ),
             ],
         )
-        filtered = BindingFilter(predicate=predicate).apply(bf)
+        filtered = BindingFilter(predicate=predicate, evaluator_factory=BindingExpressionEvaluator).apply(bf)
         assert len(filtered) == 1
         assert list(filtered.get_property("p", "name")) == ["Alice"]
 
@@ -765,7 +765,7 @@ class TestBindingFilter:
             left=PropertyLookup(expression=Variable(name="p"), property="age"),
             right=IntegerLiteral(value=100),
         )
-        filtered = BindingFilter(predicate=predicate).apply(bf)
+        filtered = BindingFilter(predicate=predicate, evaluator_factory=BindingExpressionEvaluator).apply(bf)
         assert len(filtered) == 0
 
     def test_filter_all_match(self, ctx: Context) -> None:
@@ -783,7 +783,7 @@ class TestBindingFilter:
             left=PropertyLookup(expression=Variable(name="p"), property="age"),
             right=IntegerLiteral(value=0),
         )
-        filtered = BindingFilter(predicate=predicate).apply(bf)
+        filtered = BindingFilter(predicate=predicate, evaluator_factory=BindingExpressionEvaluator).apply(bf)
         assert len(filtered) == 3
 
     def test_filter_after_join(self, ctx: Context) -> None:
@@ -811,7 +811,7 @@ class TestBindingFilter:
             ),
             right=StringLiteral(value="Alice"),
         )
-        filtered = BindingFilter(predicate=predicate).apply(joined)
+        filtered = BindingFilter(predicate=predicate, evaluator_factory=BindingExpressionEvaluator).apply(joined)
         # Alice has 2 outgoing KNOWS edges
         assert len(filtered) == 2
         assert all(filtered.get_property("p", "name") == "Alice")

--- a/tests/test_boolean_evaluator.py
+++ b/tests/test_boolean_evaluator.py
@@ -11,6 +11,7 @@ import operator
 
 import pandas as pd
 import pytest
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.binding_frame import BindingFrame
 from pycypher.boolean_evaluator import (
     _BOOL_FOLD_OPS,
@@ -200,11 +201,11 @@ class TestBooleanExpressionEvaluator:
         test_frame: BindingFrame,
     ) -> BooleanExpressionEvaluator:
         """Create BooleanExpressionEvaluator instance."""
-        return BooleanExpressionEvaluator(test_frame)
+        return BooleanExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
 
     def test_evaluator_initialization(self, test_frame: BindingFrame) -> None:
         """Test evaluator initializes correctly."""
-        evaluator = BooleanExpressionEvaluator(test_frame)
+        evaluator = BooleanExpressionEvaluator(test_frame, evaluator_factory=BindingExpressionEvaluator)
         assert evaluator.frame is test_frame
 
     def test_evaluate_and_basic(
@@ -496,7 +497,7 @@ class TestBooleanEvaluatorIntegration:
             context=context,
             type_registry={"x": "X"},
         )
-        evaluator = BooleanExpressionEvaluator(frame)
+        evaluator = BooleanExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
 
         class MockEval:
             """Mock that maps string labels to predetermined series."""
@@ -758,7 +759,7 @@ class TestBooleanEvaluatorRegression:
             context=context,
             type_registry={"x": "X"},
         )
-        ev = BooleanExpressionEvaluator(frame)
+        ev = BooleanExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
 
         class MockEval:
             """Mock evaluator for regression test."""

--- a/tests/test_collection_evaluator_deep_coverage.py
+++ b/tests/test_collection_evaluator_deep_coverage.py
@@ -16,6 +16,7 @@ import pandas as pd
 import pytest
 from pycypher import ContextBuilder, Star
 from pycypher.ast_models import MapLiteral
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.binding_frame import BindingFrame
 from pycypher.collection_evaluator import CollectionExpressionEvaluator
 
@@ -126,7 +127,7 @@ class TestPatternComprehension:
             type_registry={"p": "Person"},
             context=ctx,
         )
-        evaluator = CollectionExpressionEvaluator(frame)
+        evaluator = CollectionExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
 
         class FakePC:
             variable: Any = None
@@ -162,7 +163,7 @@ class TestMapLiteralEdgePaths:
             type_registry={"p": "Person"},
             context=ctx,
         )
-        evaluator = CollectionExpressionEvaluator(frame)
+        evaluator = CollectionExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
 
         ml = MapLiteral(entries={}, value={})
 
@@ -184,7 +185,7 @@ class TestMapLiteralEdgePaths:
             type_registry={"p": "Person"},
             context=ctx,
         )
-        evaluator = CollectionExpressionEvaluator(frame)
+        evaluator = CollectionExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
 
         ml = MapLiteral(entries={}, value={"x": 42, "y": "hello"})
 
@@ -258,7 +259,7 @@ class TestMapProjectionEmpty:
             type_registry={"p": "Person"},
             context=ctx,
         )
-        evaluator = CollectionExpressionEvaluator(frame)
+        evaluator = CollectionExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
 
         class FakeVariable:
             name: str = "p"

--- a/tests/test_comparison_evaluator_edge_cases.py
+++ b/tests/test_comparison_evaluator_edge_cases.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.comparison_evaluator import ComparisonEvaluator
 from pycypher.exceptions import UnsupportedOperatorError
 
@@ -28,7 +29,7 @@ def _make_evaluator(n: int = 3) -> tuple[ComparisonEvaluator, MagicMock]:
     """Build a ComparisonEvaluator with a mocked frame of length n."""
     frame = MagicMock()
     frame.__len__ = MagicMock(return_value=n)
-    return ComparisonEvaluator(frame), frame
+    return ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator), frame
 
 
 def _mock_parent_evaluator(*series_list: pd.Series) -> MagicMock:

--- a/tests/test_core_evaluator_coverage.py
+++ b/tests/test_core_evaluator_coverage.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.arithmetic_evaluator import (
     ArithmeticExpressionEvaluator,
     _cypher_div,
@@ -320,7 +321,7 @@ class TestArithmeticEvaluatorClass:
 
     def test_evaluate_arithmetic_add(self) -> None:
         frame = _make_frame(3)
-        ev = ArithmeticExpressionEvaluator(frame)
+        ev = ArithmeticExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         left_s = pd.Series([1, 2, 3])
         right_s = pd.Series([10, 20, 30])
         mock_eval = _make_evaluator({"L": left_s, "R": right_s})
@@ -329,14 +330,14 @@ class TestArithmeticEvaluatorClass:
 
     def test_evaluate_arithmetic_unsupported_op(self) -> None:
         frame = _make_frame(1)
-        ev = ArithmeticExpressionEvaluator(frame)
+        ev = ArithmeticExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator({"L": pd.Series([1]), "R": pd.Series([2])})
         with pytest.raises(UnsupportedOperatorError):
             ev.evaluate_arithmetic("@", "L", "R", mock_eval)
 
     def test_evaluate_arithmetic_type_error(self) -> None:
         frame = _make_frame(1)
-        ev = ArithmeticExpressionEvaluator(frame)
+        ev = ArithmeticExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator(
             {"L": pd.Series(["a"]), "R": pd.Series([1])},
         )
@@ -345,7 +346,7 @@ class TestArithmeticEvaluatorClass:
 
     def test_evaluate_comparison(self) -> None:
         frame = _make_frame(3)
-        ev = ArithmeticExpressionEvaluator(frame)
+        ev = ArithmeticExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         left_s = pd.Series([1, 2, 3])
         right_s = pd.Series([2, 2, 2])
         mock_eval = _make_evaluator({"L": left_s, "R": right_s})
@@ -354,7 +355,7 @@ class TestArithmeticEvaluatorClass:
 
     def test_evaluate_comparison_null_three_valued(self) -> None:
         frame = _make_frame(2)
-        ev = ArithmeticExpressionEvaluator(frame)
+        ev = ArithmeticExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         left_s = pd.Series([1, None], dtype=object)
         right_s = pd.Series([1, 2])
         mock_eval = _make_evaluator({"L": left_s, "R": right_s})
@@ -364,28 +365,28 @@ class TestArithmeticEvaluatorClass:
 
     def test_evaluate_comparison_unsupported_op(self) -> None:
         frame = _make_frame(1)
-        ev = ArithmeticExpressionEvaluator(frame)
+        ev = ArithmeticExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator({"L": pd.Series([1]), "R": pd.Series([2])})
         with pytest.raises(UnsupportedOperatorError):
             ev.evaluate_comparison("!=", "L", "R", mock_eval)
 
     def test_evaluate_unary_neg(self) -> None:
         frame = _make_frame(3)
-        ev = ArithmeticExpressionEvaluator(frame)
+        ev = ArithmeticExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator({"X": pd.Series([1, -2, 3])})
         result = ev.evaluate_unary("-", "X", mock_eval)
         assert list(result) == [-1, 2, -3]
 
     def test_evaluate_unary_pos(self) -> None:
         frame = _make_frame(2)
-        ev = ArithmeticExpressionEvaluator(frame)
+        ev = ArithmeticExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator({"X": pd.Series([5, -3])})
         result = ev.evaluate_unary("+", "X", mock_eval)
         assert list(result) == [5, -3]
 
     def test_evaluate_unary_null_propagation(self) -> None:
         frame = _make_frame(2)
-        ev = ArithmeticExpressionEvaluator(frame)
+        ev = ArithmeticExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator({"X": pd.Series([1, None], dtype=object)})
         result = ev.evaluate_unary("-", "X", mock_eval)
         assert result.iloc[0] == -1
@@ -393,7 +394,7 @@ class TestArithmeticEvaluatorClass:
 
     def test_evaluate_unary_unsupported(self) -> None:
         frame = _make_frame(1)
-        ev = ArithmeticExpressionEvaluator(frame)
+        ev = ArithmeticExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator({"X": pd.Series([1])})
         with pytest.raises(UnsupportedOperatorError):
             ev.evaluate_unary("~", "X", mock_eval)
@@ -401,7 +402,7 @@ class TestArithmeticEvaluatorClass:
     def test_evaluate_arithmetic_temporal(self) -> None:
         """Arithmetic dispatch detects temporal values and routes to temporal handler."""
         frame = _make_frame(1)
-        ev = ArithmeticExpressionEvaluator(frame)
+        ev = ArithmeticExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator(
             {
                 "L": pd.Series(["2024-01-15"]),
@@ -513,7 +514,7 @@ class TestKleeneNot:
 class TestBooleanEvaluatorClass:
     def test_evaluate_and_all_true(self) -> None:
         frame = _make_frame(2)
-        ev = BooleanExpressionEvaluator(frame)
+        ev = BooleanExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator(
             {
                 "a": pd.Series([True, True]),
@@ -526,13 +527,13 @@ class TestBooleanEvaluatorClass:
 
     def test_evaluate_and_empty(self) -> None:
         frame = _make_frame(2)
-        ev = BooleanExpressionEvaluator(frame)
+        ev = BooleanExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         result = ev.evaluate_and([], MagicMock())
         assert list(result) == [True, True]
 
     def test_evaluate_or(self) -> None:
         frame = _make_frame(2)
-        ev = BooleanExpressionEvaluator(frame)
+        ev = BooleanExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator(
             {
                 "a": pd.Series([False, False]),
@@ -545,13 +546,13 @@ class TestBooleanEvaluatorClass:
 
     def test_evaluate_or_empty(self) -> None:
         frame = _make_frame(2)
-        ev = BooleanExpressionEvaluator(frame)
+        ev = BooleanExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         result = ev.evaluate_or([], MagicMock())
         assert list(result) == [False, False]
 
     def test_evaluate_not(self) -> None:
         frame = _make_frame(2)
-        ev = BooleanExpressionEvaluator(frame)
+        ev = BooleanExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator({"x": pd.Series([True, False])})
         result = ev.evaluate_not("x", mock_eval)
         assert bool(result.iloc[0]) is False
@@ -559,7 +560,7 @@ class TestBooleanEvaluatorClass:
 
     def test_evaluate_xor(self) -> None:
         frame = _make_frame(2)
-        ev = BooleanExpressionEvaluator(frame)
+        ev = BooleanExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator(
             {
                 "a": pd.Series([True, True]),
@@ -572,13 +573,13 @@ class TestBooleanEvaluatorClass:
 
     def test_evaluate_xor_empty(self) -> None:
         frame = _make_frame(2)
-        ev = BooleanExpressionEvaluator(frame)
+        ev = BooleanExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         result = ev.evaluate_xor([], MagicMock())
         assert list(result) == [False, False]
 
     def test_evaluate_bool_chain_and(self) -> None:
         frame = _make_frame(2)
-        ev = BooleanExpressionEvaluator(frame)
+        ev = BooleanExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator(
             {
                 "a": pd.Series([True, True]),
@@ -591,13 +592,13 @@ class TestBooleanEvaluatorClass:
 
     def test_evaluate_bool_chain_unsupported(self) -> None:
         frame = _make_frame(1)
-        ev = BooleanExpressionEvaluator(frame)
+        ev = BooleanExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         with pytest.raises(UnsupportedOperatorError):
             ev.evaluate_bool_chain("nand", ["a"], MagicMock())
 
     def test_evaluate_bool_chain_empty(self) -> None:
         frame = _make_frame(2)
-        ev = BooleanExpressionEvaluator(frame)
+        ev = BooleanExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         result = ev.evaluate_bool_chain("or", [], MagicMock())
         assert list(result) == [False, False]
 
@@ -610,7 +611,7 @@ class TestBooleanEvaluatorClass:
 class TestComparisonEvaluatorClass:
     def test_evaluate_comparison_eq(self) -> None:
         frame = _make_frame(3)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator(
             {
                 "L": pd.Series([1, 2, 3]),
@@ -622,7 +623,7 @@ class TestComparisonEvaluatorClass:
 
     def test_evaluate_comparison_null_propagation(self) -> None:
         frame = _make_frame(2)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator(
             {
                 "L": pd.Series([1, None], dtype=object),
@@ -634,14 +635,14 @@ class TestComparisonEvaluatorClass:
 
     def test_evaluate_comparison_unsupported_op(self) -> None:
         frame = _make_frame(1)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator({"L": pd.Series([1]), "R": pd.Series([2])})
         with pytest.raises(UnsupportedOperatorError):
             ev.evaluate_comparison("!=", "L", "R", mock_eval)
 
     def test_evaluate_null_check_is_null(self) -> None:
         frame = _make_frame(3)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator(
             {"X": pd.Series([1, None, 3], dtype=object)},
         )
@@ -650,7 +651,7 @@ class TestComparisonEvaluatorClass:
 
     def test_evaluate_null_check_is_not_null(self) -> None:
         frame = _make_frame(3)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator(
             {"X": pd.Series([1, None, 3], dtype=object)},
         )
@@ -659,35 +660,35 @@ class TestComparisonEvaluatorClass:
 
     def test_evaluate_null_check_unsupported(self) -> None:
         frame = _make_frame(1)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator({"X": pd.Series([1])})
         with pytest.raises(UnsupportedOperatorError):
             ev.evaluate_null_check("IS EMPTY", "X", mock_eval)
 
     def test_evaluate_unary_neg(self) -> None:
         frame = _make_frame(2)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator({"X": pd.Series([5, -3])})
         result = ev.evaluate_unary("-", "X", mock_eval)
         assert list(result) == [-5, 3]
 
     def test_evaluate_unary_pos(self) -> None:
         frame = _make_frame(2)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator({"X": pd.Series([5, -3])})
         result = ev.evaluate_unary("+", "X", mock_eval)
         assert list(result) == [5, -3]
 
     def test_evaluate_unary_null_propagation(self) -> None:
         frame = _make_frame(2)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator({"X": pd.Series([1, None], dtype=object)})
         result = ev.evaluate_unary("-", "X", mock_eval)
         assert result.iloc[1] is None
 
     def test_evaluate_unary_unsupported(self) -> None:
         frame = _make_frame(1)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         mock_eval = _make_evaluator({"X": pd.Series([1])})
         with pytest.raises(UnsupportedOperatorError):
             ev.evaluate_unary("~", "X", mock_eval)
@@ -695,7 +696,7 @@ class TestComparisonEvaluatorClass:
     def test_evaluate_case_searched(self) -> None:
         """Searched CASE: CASE WHEN cond THEN val ELSE default END."""
         frame = _make_frame(3)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
 
         cond_series = pd.Series([True, False, True])
         then_series = pd.Series(["yes", "yes", "yes"])
@@ -719,7 +720,7 @@ class TestComparisonEvaluatorClass:
     def test_evaluate_case_simple(self) -> None:
         """Simple CASE: CASE expr WHEN match THEN val END."""
         frame = _make_frame(3)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
 
         disc_series = pd.Series([1, 2, 3])
         match_series = pd.Series([2, 2, 2])
@@ -741,7 +742,7 @@ class TestComparisonEvaluatorClass:
     def test_evaluate_case_no_else_yields_none(self) -> None:
         """CASE with no ELSE and no matching WHEN → null."""
         frame = _make_frame(2)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
 
         cond_series = pd.Series([False, False])
         then_series = pd.Series(["x", "x"])
@@ -755,7 +756,7 @@ class TestComparisonEvaluatorClass:
     def test_evaluate_case_multiple_whens_first_wins(self) -> None:
         """First matching WHEN clause wins."""
         frame = _make_frame(1)
-        ev = ComparisonEvaluator(frame)
+        ev = ComparisonEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
 
         clause1 = SimpleNamespace(condition="c1", result="t1")
         clause2 = SimpleNamespace(condition="c2", result="t2")

--- a/tests/test_entity_scan_pushdown.py
+++ b/tests/test_entity_scan_pushdown.py
@@ -17,6 +17,7 @@ import time
 
 import pandas as pd
 import pytest
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.constants import (
     ID_COLUMN,
     RELATIONSHIP_SOURCE_COLUMN,
@@ -409,7 +410,7 @@ class TestPushdownPerformance:
         t0 = time.perf_counter()
         for _ in range(20):
             frame = EntityScan("Person", "a").scan(large_context)
-            BindingFilter(predicate=predicate).apply(frame)
+            BindingFilter(predicate=predicate, evaluator_factory=BindingExpressionEvaluator).apply(frame)
         filter_time = time.perf_counter() - t0
 
         assert pushdown_time < filter_time, (

--- a/tests/test_exists_evaluator_unit.py
+++ b/tests/test_exists_evaluator_unit.py
@@ -26,6 +26,7 @@ from pycypher.ast_models import (
     ReturnItem,
     Variable,
 )
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.binding_frame import BindingFrame
 from pycypher.exceptions import PatternComprehensionError
 from pycypher.exists_evaluator import _EXISTS_SENTINEL, ExistsEvaluator
@@ -121,7 +122,7 @@ class TestEvaluateExistsEdgeCases:
         evaluator_mock: MagicMock,
     ) -> None:
         """Content that is neither Pattern nor Query → all False."""
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_exists("not a pattern", evaluator_mock)
         assert list(result) == [False, False, False]
 
@@ -131,7 +132,7 @@ class TestEvaluateExistsEdgeCases:
         evaluator_mock: MagicMock,
     ) -> None:
         """None content → all False."""
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_exists(None, evaluator_mock)
         assert list(result) == [False, False, False]
 
@@ -141,7 +142,7 @@ class TestEvaluateExistsEdgeCases:
         evaluator_mock: MagicMock,
     ) -> None:
         """Arbitrary non-AST content → all False."""
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_exists(42, evaluator_mock)
         assert list(result) == [False, False, False]
 
@@ -156,7 +157,7 @@ class TestEvaluateExistsEdgeCases:
             type_registry={"p": "Person"},
             context=simple_context,
         )
-        ee = ExistsEvaluator(empty_frame)
+        ee = ExistsEvaluator(empty_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_exists("anything", evaluator_mock)
         assert len(result) == 0
 
@@ -187,7 +188,7 @@ class TestEvaluateExistsQuery:
         match = Match(pattern=pattern, where=None)
         subquery = Query(clauses=[match])  # No RETURN
 
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_exists(subquery, evaluator_mock)
 
         # Alice (id=1) knows Bob and Carol → True
@@ -218,7 +219,7 @@ class TestEvaluateExistsQuery:
         )
         subquery = Query(clauses=[match, ret])
 
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_exists(subquery, evaluator_mock)
 
         assert result.dtype == bool
@@ -249,7 +250,7 @@ class TestEvaluateExistsPattern:
         path = PatternPath(elements=[source, rel, target])
         pattern = Pattern(paths=[path])
 
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_exists(pattern, evaluator_mock)
 
         assert result.dtype == bool
@@ -279,7 +280,7 @@ class TestEvaluateExistsPattern:
         path = PatternPath(elements=[source, rel1, mid, rel2, target])
         pattern = Pattern(paths=[path])
 
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_exists(pattern, evaluator_mock)
 
         # Result should be boolean series of correct length
@@ -293,7 +294,7 @@ class TestEvaluateExistsPattern:
     ) -> None:
         """Pattern with no paths → falls back to query (0 elements != 3)."""
         pattern = Pattern(paths=[])
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_exists(pattern, evaluator_mock)
         # Empty pattern with no paths: content.paths is empty list,
         # so the multi-hop check fails and it falls to query execution
@@ -320,7 +321,7 @@ class TestPatternComprehensionErrors:
             where=None,
             map_expr=None,
         )
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_pattern_comprehension(pc, evaluator_mock)
         assert all(lst == [] for lst in result)
 
@@ -336,7 +337,7 @@ class TestPatternComprehensionErrors:
             where=None,
             map_expr=None,
         )
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_pattern_comprehension(pc, evaluator_mock)
         assert all(lst == [] for lst in result)
 
@@ -367,7 +368,7 @@ class TestPatternComprehensionErrors:
             where=None,
             map_expr=None,
         )
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         with pytest.raises(PatternComprehensionError, match="single-hop"):
             ee.evaluate_pattern_comprehension(pc, evaluator_mock)
 
@@ -396,7 +397,7 @@ class TestPatternComprehensionErrors:
             where=None,
             map_expr=None,
         )
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         with pytest.raises(PatternComprehensionError, match="NodePattern"):
             ee.evaluate_pattern_comprehension(pc, evaluator_mock)
 
@@ -417,7 +418,7 @@ class TestPatternComprehensionErrors:
             where=None,
             map_expr=None,
         )
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         with pytest.raises(
             PatternComprehensionError, match="RelationshipPattern"
         ):
@@ -452,7 +453,7 @@ class TestPatternComprehensionFunctional:
             where=None,
             map_expr=None,
         )
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_pattern_comprehension(pc, evaluator_mock)
 
         # Alice (1) knows Bob (2) and Carol (3)
@@ -481,7 +482,7 @@ class TestPatternComprehensionFunctional:
             where=None,
             map_expr=None,
         )
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_pattern_comprehension(pc, evaluator_mock)
 
         # Alice (1) has no incoming KNOWS
@@ -511,7 +512,7 @@ class TestPatternComprehensionFunctional:
             where=None,
             map_expr=None,
         )
-        ee = ExistsEvaluator(alice_frame)
+        ee = ExistsEvaluator(alice_frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_pattern_comprehension(pc, evaluator_mock)
 
         assert all(lst == [] for lst in result)
@@ -542,7 +543,7 @@ class TestPatternComprehensionFunctional:
             where=None,
             map_expr=None,
         )
-        ee = ExistsEvaluator(frame)
+        ee = ExistsEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_pattern_comprehension(pc, evaluator_mock)
 
         # f=2 (Bob) is target of Alice(1)->Bob(2), so anchor flips: source=1
@@ -575,7 +576,7 @@ class TestPatternComprehensionFunctional:
             where=None,
             map_expr=None,
         )
-        ee = ExistsEvaluator(frame)
+        ee = ExistsEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee.evaluate_pattern_comprehension(pc, evaluator_mock)
         assert all(lst == [] for lst in result)
 
@@ -625,6 +626,6 @@ class TestExistsViaQueryExecution:
         )
         subquery = Query(clauses=[match, ret])
 
-        ee = ExistsEvaluator(frame)
+        ee = ExistsEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
         result = ee._exists_via_query_execution(subquery)
         assert list(result) == [False, False, False]

--- a/tests/test_mutation_engine_coverage.py
+++ b/tests/test_mutation_engine_coverage.py
@@ -8,6 +8,7 @@ process_foreach, remove_properties, and process_call with YIELD.
 from __future__ import annotations
 
 import pandas as pd
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.mutation_engine import MutationEngine
 from pycypher.relational_models import (
     ID_COLUMN,
@@ -91,19 +92,19 @@ class TestNextEntityIds:
 
     def test_ids_start_after_max_existing(self) -> None:
         ctx = _people_context()
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         ids = engine.next_entity_ids("Person", 3)
         assert list(ids) == [4, 5, 6]
 
     def test_ids_for_new_entity_type_start_at_1(self) -> None:
         ctx = _people_context()
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         ids = engine.next_entity_ids("Animal", 2)
         assert list(ids) == [1, 2]
 
     def test_ids_account_for_shadow_layer(self) -> None:
         ctx = _people_context()
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         # Seed shadow with higher IDs
         ctx._shadow["Person"] = pd.DataFrame({ID_COLUMN: [1, 2, 3, 10]})
         ids = engine.next_entity_ids("Person", 2)
@@ -121,7 +122,7 @@ class TestNextEntityIds:
             attribute_map={},
             source_obj=str_df,
         )
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         ids = engine.next_entity_ids("Foo", 1)
         # Falls back to 0 and starts at 1
         assert list(ids) == [1]
@@ -132,19 +133,19 @@ class TestNextRelationshipIds:
 
     def test_ids_start_after_max_existing(self) -> None:
         ctx = _people_context(with_relationships=True)
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         ids = engine.next_relationship_ids("KNOWS", 2)
         assert list(ids) == [102, 103]
 
     def test_ids_for_new_rel_type_start_at_1(self) -> None:
         ctx = _people_context()
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         ids = engine.next_relationship_ids("LIKES", 3)
         assert list(ids) == [1, 2, 3]
 
     def test_ids_account_for_shadow_rels(self) -> None:
         ctx = _people_context(with_relationships=True)
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         ctx._shadow_rels["KNOWS"] = pd.DataFrame(
             {
                 ID_COLUMN: [100, 101, 200],
@@ -157,7 +158,7 @@ class TestNextRelationshipIds:
 
     def test_ids_handle_non_integer_rel_ids(self) -> None:
         ctx = _people_context(with_relationships=True)
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         # Shadow with string ID
         ctx._shadow_rels["KNOWS"] = pd.DataFrame(
             {
@@ -181,7 +182,7 @@ class TestShadowCreateEntity:
 
     def test_creates_into_new_type(self) -> None:
         ctx = _empty_context()
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         engine.shadow_create_entity(
             "Animal",
             [1, 2],
@@ -193,14 +194,14 @@ class TestShadowCreateEntity:
 
     def test_appends_to_existing_shadow(self) -> None:
         ctx = _empty_context()
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         engine.shadow_create_entity("Animal", [1], {"species": ["Cat"]})
         engine.shadow_create_entity("Animal", [2], {"species": ["Dog"]})
         assert len(ctx._shadow["Animal"]) == 2
 
     def test_seeds_from_live_table_when_no_shadow(self) -> None:
         ctx = _people_context()
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         engine.shadow_create_entity(
             "Person",
             [4],
@@ -212,7 +213,7 @@ class TestShadowCreateEntity:
 
     def test_updates_attribute_map_for_new_columns(self) -> None:
         ctx = _people_context()
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         engine.shadow_create_entity(
             "Person",
             [4],
@@ -228,7 +229,7 @@ class TestShadowCreateRelationship:
 
     def test_creates_into_new_rel_type(self) -> None:
         ctx = _empty_context()
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         engine.shadow_create_relationship("LIKES", [1], [10], [20])
         shadow = ctx._shadow_rels["LIKES"]
         assert len(shadow) == 1
@@ -237,7 +238,7 @@ class TestShadowCreateRelationship:
 
     def test_seeds_from_live_rel_table(self) -> None:
         ctx = _people_context(with_relationships=True)
-        engine = MutationEngine(context=ctx)
+        engine = MutationEngine(context=ctx, evaluator_factory=BindingExpressionEvaluator)
         engine.shadow_create_relationship("KNOWS", [102], [3], [1])
         shadow = ctx._shadow_rels["KNOWS"]
         assert len(shadow) == 3  # 2 existing + 1 new

--- a/tests/test_pattern_matcher_unit.py
+++ b/tests/test_pattern_matcher_unit.py
@@ -19,6 +19,7 @@ from pycypher.ast_models import (
     RelationshipPattern,
     Variable,
 )
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.binding_frame import BindingFrame
 from pycypher.path_expander import PathExpander
 from pycypher.pattern_matcher import (
@@ -168,6 +169,7 @@ def _make_matcher(ctx: Context) -> PatternMatcher:
         path_expander=expander,
         coerce_join_fn=_identity_join,
         apply_where_fn=_noop_where,
+        evaluator_factory=BindingExpressionEvaluator,
     )
 
 
@@ -475,6 +477,7 @@ class TestMatchToBindingFrame:
             path_expander=expander,
             coerce_join_fn=_identity_join,
             apply_where_fn=tracking_where,
+            evaluator_factory=BindingExpressionEvaluator,
         )
 
         from pycypher.ast_models import IntegerLiteral
@@ -839,6 +842,7 @@ class TestPredicatePushdown:
             path_expander=expander,
             coerce_join_fn=_identity_join,
             apply_where_fn=tracking_where,
+            evaluator_factory=BindingExpressionEvaluator,
         )
 
         from pycypher.ast_models import IntegerLiteral
@@ -899,6 +903,7 @@ class TestPredicatePushdown:
             path_expander=expander,
             coerce_join_fn=_identity_join,
             apply_where_fn=tracking_where,
+            evaluator_factory=BindingExpressionEvaluator,
         )
 
         # WHERE references both 'a' and 'b' — cannot push down

--- a/tests/test_performance_quantifier_vectorization.py
+++ b/tests/test_performance_quantifier_vectorization.py
@@ -15,6 +15,7 @@ from unittest.mock import Mock, patch
 import pandas as pd
 import pytest
 from _perf_helpers import perf_threshold
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.binding_frame import BindingFrame
 from pycypher.collection_evaluator import CollectionExpressionEvaluator
 from pycypher.ingestion import ContextBuilder
@@ -119,7 +120,7 @@ class TestQuantifierVectorizationImplementation:
     def test_vectorized_eval_quantifier_method_exists(self):
         """Test that vectorized eval_quantifier method exists in CollectionExpressionEvaluator."""
         frame = Mock()
-        evaluator = CollectionExpressionEvaluator(frame)
+        evaluator = CollectionExpressionEvaluator(frame, evaluator_factory=BindingExpressionEvaluator)
 
         # After implementation, this method should exist
         # In red phase: will fail because method doesn't exist yet

--- a/tests/test_projection_planner.py
+++ b/tests/test_projection_planner.py
@@ -23,6 +23,7 @@ from pycypher.ast_models import (
     ReturnItem,
     Variable,
 )
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.projection_planner import ProjectionPlanner
 
 # ---------------------------------------------------------------------------
@@ -44,7 +45,9 @@ def _make_planner(
         renderer.render = MagicMock(return_value=None)
     if where_fn is None:
         where_fn = MagicMock()
-    return ProjectionPlanner(agg_planner, renderer, where_fn)
+    return ProjectionPlanner(
+        agg_planner, renderer, where_fn, evaluator_factory=BindingExpressionEvaluator
+    )
 
 
 def _prop(var_name: str, prop_name: str) -> PropertyLookup:

--- a/tests/test_scalar_function_evaluator_unit.py
+++ b/tests/test_scalar_function_evaluator_unit.py
@@ -23,6 +23,7 @@ import pandas as pd
 import pytest
 from pycypher.ast_models import Literal, Variable
 from pycypher.binding_frame import PATH_HOP_COLUMN_PREFIX, BindingFrame
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher.scalar_function_evaluator import ScalarFunctionEvaluator
 from pycypher.star import Star
 
@@ -35,7 +36,7 @@ class TestScalarFunctionEvaluatorUnit:
         minimal_binding_frame: BindingFrame,
     ) -> None:
         """Test ScalarFunctionEvaluator can be instantiated with a binding frame."""
-        evaluator = ScalarFunctionEvaluator(minimal_binding_frame)
+        evaluator = ScalarFunctionEvaluator(minimal_binding_frame, evaluator_factory=BindingExpressionEvaluator)
 
         assert evaluator.frame is minimal_binding_frame
         assert hasattr(evaluator, "evaluate_scalar_function")
@@ -45,7 +46,7 @@ class TestScalarFunctionEvaluatorUnit:
         minimal_binding_frame: BindingFrame,
     ) -> None:
         """Test that the frame reference is stored correctly and remains consistent."""
-        evaluator = ScalarFunctionEvaluator(minimal_binding_frame)
+        evaluator = ScalarFunctionEvaluator(minimal_binding_frame, evaluator_factory=BindingExpressionEvaluator)
         original_frame = evaluator.frame
 
         # Frame reference should remain the same
@@ -205,7 +206,7 @@ class TestPathLengthFunction:
             },
         )
 
-        evaluator = ScalarFunctionEvaluator(mock_frame)
+        evaluator = ScalarFunctionEvaluator(mock_frame, evaluator_factory=BindingExpressionEvaluator)
 
         # Mock Variable for path argument
         path_var = Variable(name="mypath")
@@ -428,7 +429,7 @@ class TestErrorHandling:
         mock_frame = Mock()
         mock_frame.bindings = pd.DataFrame({"other_col": [1, 2, 3]})
 
-        evaluator = ScalarFunctionEvaluator(mock_frame)
+        evaluator = ScalarFunctionEvaluator(mock_frame, evaluator_factory=BindingExpressionEvaluator)
         path_var = Variable(name="missing_path")
 
         # Should fall through since hop column doesn't exist
@@ -588,4 +589,4 @@ def minimal_scalar_evaluator(
     minimal_binding_frame: BindingFrame,
 ) -> ScalarFunctionEvaluator:
     """Create a minimal ScalarFunctionEvaluator for testing."""
-    return ScalarFunctionEvaluator(minimal_binding_frame)
+    return ScalarFunctionEvaluator(minimal_binding_frame, evaluator_factory=BindingExpressionEvaluator)

--- a/tests/test_string_predicate_evaluator_coverage.py
+++ b/tests/test_string_predicate_evaluator_coverage.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import pandas as pd
 import pytest
+from pycypher.binding_evaluator import BindingExpressionEvaluator
 from pycypher import Star
 from pycypher.exceptions import UnsupportedOperatorError
 from pycypher.ingestion import ContextBuilder
@@ -329,7 +330,7 @@ class TestUnsupportedOperator:
 
     def test_unknown_op_raises(self) -> None:
         """Calling evaluate_string_predicate with an unknown op raises."""
-        evaluator = StringPredicateEvaluator()
+        evaluator = StringPredicateEvaluator(evaluator_factory=BindingExpressionEvaluator)
 
         # Build a minimal mock for the evaluator protocol
         class _FakeExpr:


### PR DESCRIPTION
## Summary
- Replaces deferred `from pycypher.binding_evaluator import BindingExpressionEvaluator` construct-directly call sites with a constructor-injected `evaluator_factory` (`ExpressionEvaluatorFactory` protocol) across all 8 sub-evaluators, `MutationEngine`, `ProjectionPlanner`, `AggregationPlanner`, `PatternMatcher`, `BindingFilter`, and `ClauseExecutor`, wired from `Star.__init__`.
- Rewrites `ClauseExecutor.dispatch_clause`'s 11-branch `isinstance` ladder into a `dict[type, Callable]` table built once in `__init__`, with one handler method per clause type.
- Fixes 5 tests in `test_aggregation_planner.py` that patched the module-level `BindingExpressionEvaluator` name — no longer effective now that the factory is injected at construction time — by injecting the mock factory directly instead.

## Test plan
- [x] `uv run pytest tests/ -q` (excluding the always-deselected large-dataset compat test and two known-flaky Dask distributed-cluster tests unrelated to this change): 9999 passed, 1 pre-existing unrelated failure (`test_dataframe_copy_failures.py`, confirmed failing identically without these changes), 36 skipped, 5 xfailed.
- [x] `uv run python scripts/check_import_cycles.py --ratchet` passes (no growth vs. baseline).
- [x] Standalone `python -c "import pycypher.<mod>"` succeeds for `star`, `clause_executor`, `mutation_engine`, `projection_planner`, `aggregation_planner`, `scan_operators`.

Note: `check_import_cycles.py` reports the same 34-module SCC as before this change, because it doesn't distinguish real module-level imports from `TYPE_CHECKING`-guarded or function-body (deferred) imports. A manual analysis restricted to genuine top-level imports confirms the real runtime cycle is unrelated to this change's target modules (5 modules: `pycypher`, `pycypher.ingestion`, `pycypher.ingestion.context_builder`, `pycypher.relational_models`, `pycypher.star`) — fixing the script itself is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)